### PR TITLE
Attempt to Fix some broken links and images in ITALIAN.md

### DIFF
--- a/translations/ITALIAN.md
+++ b/translations/ITALIAN.md
@@ -23,9 +23,9 @@ Se sei un nuovo sviluppatore e ti stai chiedendo se devi imparare Git e GitHub, 
 
 ## A Che cosa andrò a contribuire?
 
-![Contributor Card](readme-only/card.PNG 'Contributor Card')
+![Contributor Card](/readme-only/card.PNG 'Contributor Card')
 
-Contribuirai con una card come questa alla  [pagina web del progetto] (https://syknapse.github.io/Contribute-To-This-Project/ 'https://syknapse.github.io/Contribute-To-This-Project'). Includerà il tuo nome, il tuo Twitter handle , una breve descrizione e 3 collegamenti a risorse utili per gli sviluppatori web.
+Contribuirai con una card come questa alla [pagina web del progetto](https://syknapse.github.io/Contribute-To-This-Project/ 'https://syknapse.github.io/Contribute-To-This-Project'). Includerà il tuo nome, il tuo Twitter handle , una breve descrizione e 3 collegamenti a risorse utili per gli sviluppatori web.
 
 Farai una copia del modello di questa card all'interno del file HTML e lo personalizzerai con le tue informazioni.
 
@@ -42,8 +42,8 @@ Prima di tutto facciamo il setup per iniziare a lavorare
 1. Esegui il login del tuo account GitHub. Se non hai ancora un account, [unisciti a GitHub](https://github.com/join). Ti consiglio di fare il [tutorial GitHub Hello World](https://guides.github.com/activities/hello-world/) prima di continuare.
 2. Esegui il Download di [GitHub Desktop app](https://desktop.github.com/).			
 
--	 In alternativa, se hai dimestichezza con Git dalla riga di comando, puoi farlo (ecco [first-contributions] (https://github.com/Syknapse/first-contributions), un progetto simile che può servire da guida per i comandi necessario). 
--	 Altrimenti se usi [VS Code] (https://code.visualstudio.com/ 'Sito Web di Visual Studio Code') viene fornito con Git integrato e ti consente di fare ciò di cui abbiamo bisogno direttamente dall'editor.
+-	 In alternativa, se hai dimestichezza con Git dalla riga di comando, puoi farlo (ecco [first-contributions](https://github.com/Syknapse/first-contributions), un progetto simile che può servire da guida per i comandi necessario). 
+-	 Altrimenti se usi [VS Code](https://code.visualstudio.com/ 'Sito Web di Visual Studio Code') viene fornito con Git integrato e ti consente di fare ciò di cui abbiamo bisogno direttamente dall'editor.
 -	 Tuttavia, il modo più semplice per seguire questa esercitazione è utilizzare GitHub Desktop.
 
 Ora che sei pronto, iniziamo con l'attività di contribuzione al progetto.
@@ -64,7 +64,7 @@ _ Tempo stimato: meno di 30 minuti_.
 - Un repository (repo) è il modo in cui un progetto viene chiamato su GitHub e un fork corrisponde a una copia.
 - Assicurati di essere nella [pagina principale] (https://github.com/Syknapse/Contribute-To-This-Project 'https://github.com/Syknapse/Contribute-To-This-Project') di questo repo.
 
-| <ul><li>Fai click sul bottone _Fork_ </li></ul> | ![Fork](readme-only/fork.PNG "fai click su 'Fork'") |
+| <ul><li>Fai click sul bottone _Fork_ </li></ul> | ![Fork](/readme-only/fork.PNG "fai click su 'Fork'") |
 | :------------------------------------------- | ----------------------------------------------: |
 
 
@@ -77,13 +77,13 @@ _ Tempo stimato: meno di 30 minuti_.
 -	Ora vogliamo fare una copia locale del progetto. Questa è una copia salvata sul tuo computer.
 -	Apri l'app desktop GitHub. Nell'app:
 
-| <ul><li>Fai click su _File_ e successivamente su _Clone repository_</li></ul> | ![Clone](readme-only/clone.PNG 'fai click su clone repository') |
+| <ul><li>Fai click su _File_ e successivamente su _Clone repository_</li></ul> | ![Clone](/readme-only/clone.PNG 'fai click su clone repository') |
 | :-------------------------------------------------------- | -------------------------------------------------------: |
 
 
-| <ul><li>Vedrai un elenco dei tuoi progetti e fork su GitHub.</li><li>Seleziona `<il-tuo-username-github>/Contribute-To-This-Project`.</li><li>fai click su _Clone_</li></ul> | ![Clone project](readme-only/clone-project.PNG 'fai click su <il-tuo-username-github>/Contribute-To-This-Project') |
+| <ul><li>Vedrai un elenco dei tuoi progetti e fork su GitHub.</li><li>Seleziona `<il-tuo-username-github>/Contribute-To-This-Project`.</li><li>fai click su _Clone_</li></ul> | ![Clone project](/readme-only/clone-project.PNG 'fai click su <il-tuo-username-github>/Contribute-To-This-Project') |
 | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------: |
-| <ul><li>Un progetto forked avrà il simbolo del fork sulla sinistra.</li><li>Il tuo fork avrà il tuo nome utente GitHub.</li></ul>                                      |    ![your fork](readme-only/clone-your-fork.PNG 'your fork will look like this, with your own user name')    |
+| <ul><li>Un progetto forked avrà il simbolo del fork sulla sinistra.</li><li>Il tuo fork avrà il tuo nome utente GitHub.</li></ul>                                      |    ![your fork](/readme-only/clone-your-fork.PNG 'your fork will look like this, with your own user name')    |
 
 -	Questo richiederà un po' di tempo mentre il progetto viene copiato sul tuo disco rigido. Vi consiglio di mantenere il percorso predefinito che di solito è `..\Documenti\GitHub`.
 -	Ora hai una copia locale del progetto.
@@ -95,17 +95,17 @@ _ Tempo stimato: meno di 30 minuti_.
 - Dopo aver clonato il repository e averlo aperto sul desktop di GitHub, è il momento di creare un nuovo branch.
 - Un branch è un modo per mantenere separate le modifiche dalla parte principale del progetto chiamata "Master". Ad esempio, se le cose vanno male e non sei soddisfatto delle modifiche, puoi semplicemente eliminare il branch e il progetto principale non sarà compromesso.
 
-| <ul><li>Fai click su _Current branch_</li><li>e successivamente fai click su  _New_</li></ul> | ![Create branch](readme-only/branch-new.PNG "Clicca su 'Branch', successivamente 'New'") |
+| <ul><li>Fai click su _Current branch_</li><li>e successivamente fai click su  _New_</li></ul> | ![Create branch](/readme-only/branch-new.PNG "Clicca su 'Branch', successivamente 'New'") |
 | :---------------------------------------------------------------------- | ---------------------------------------------------------------------------: |
 
 
-| <ul><li>dai un nome al tuo branch</li><li>Fai click su `Create branch`</li></ul> | ![Name branch](readme-only/branch-name.PNG 'dai un nome al tuo branch') |
+| <ul><li>dai un nome al tuo branch</li><li>Fai click su `Create branch`</li></ul> | ![Name branch](/readme-only/branch-name.PNG 'dai un nome al tuo branch') |
 | :---------------------------------------------------------------------- | -------------------------------------------------------------: |
 
 
 - Puoi nominarlo come preferisci, ma dato che si tratta di un branch per aggiungere una card con il tuo nome al progetto, chiamarla "card-tuo-nome" è una buona pratica perché mantiene chiara l'intenzione di questo branch.
 
-| <ul><li>Pubblica il tuo nuovo branch su Github</li></ul> | ![Name branch](readme-only/branch-publish.PNG 'Fare clic su pubblica per inviare il nuovo branch al repo remoto su GitHub') |
+| <ul><li>Pubblica il tuo nuovo branch su Github</li></ul> | ![Name branch](/readme-only/branch-publish.PNG 'Fare clic su pubblica per inviare il nuovo branch al repo remoto su GitHub') |
 | :-------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------: |
 
 
@@ -122,7 +122,7 @@ _ Tempo stimato: meno di 30 minuti_.
 -	Trova la cartella del progetto sul tuo computer. Se hai mantenuto l'impostazione predefinita, dovrebbe essere qualcosa come `tuo-computer> Documenti> GitHub> Contribute-To-This-Project`
 -	Il file `index.html` è nella cartella` Contribute-To-This-Project`.
 
-| <ul><li>Apri il tuo editor di codice (Sublime, VS Code, Atom..etc) e usa il comando `Apri file` e individua il file index.html nella directory principale del progetto </li><li>In alternativa è possibile individuare il file sul disco rigido, fai click con il tasto destro e apri con l'editor</li></ul> | ![Open index file](readme-only/index-open.PNG 'apri index.html nel tuo editor di testo') |
+| <ul><li>Apri il tuo editor di codice (Sublime, VS Code, Atom..etc) e usa il comando `Apri file` e individua il file index.html nella directory principale del progetto </li><li>In alternativa è possibile individuare il file sul disco rigido, fai click con il tasto destro e apri con l'editor</li></ul> | ![Open index file](/readme-only/index-open.PNG 'apri index.html nel tuo editor di testo') |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -----------------------------------------------------------------------------------: |
 
 
@@ -136,41 +136,41 @@ _ Tempo stimato: meno di 30 minuti_.
 
 | <ul><li>Scorri verso il basso verso la fine del file dove troverai la sezione etichettata `== TEMPLATE ==`</li><li>Copia tutto all'interno come mostrato nel quadrato rosso nell'immagine, dal commento `Contributor card START` al commento`Contributor card END`</li></ul> |
 | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ![Copy card template](readme-only/card-copy.PNG 'Copy the card template')                                                                                                                                                                                       |
+| ![Copy card template](/readme-only/card-copy.PNG 'Copy the card template')                                                                                                                                                                                       |
 
 | <ul><li>Incolla tutto direttamente sopra il commento che indica dove posizionare il tutto</li><li>Assicurati che ci sia una sola linea di spazio tra l'inizio e la fine dell'ultima card. È buona norma mantenere il nostro codice il più chiaro possibile </li> <li> Assicurati che il rientro sia corretto e corrisponda al modello </li> </ul> |
 | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ![Paste card template](readme-only/card-paste.PNG 'Incolla sopra la linea indicata')                                                                                                                                                                                                                               |
+| ![Paste card template](/readme-only/card-paste.PNG 'Incolla sopra la linea indicata')                                                                                                                                                                                                                               |
 
--   Questa ora è la ** tua ** card pronta per essere personalizzata e modificata.
+-   Questa ora è la **tua** card pronta per essere personalizzata e modificata.
 ---
 
 ### Passaggio 6: applicare le modifiche
 
 -  Ora inizieremo a modificare l'html, cambiando i campi personalizzabili nella nostra card.
 
-| <ul><li>Sostituisci 'Name' con il tuo nome</li><li>Nota: non cambiare `class="name"`</li></ul> | ![Change name](readme-only/change-name.PNG 'Inserisci il tuo nome') |
+| <ul><li>Sostituisci 'Name' con il tuo nome</li><li>Nota: non cambiare `class="name"`</li></ul> | ![Change name](/readme-only/change-name.PNG 'Inserisci il tuo nome') |
 | :---------------------------------------------------------------------------------------- | -----------------------------------------------------------: |
 
 
 | <ul><li>Inserisci l'URL del tuo account Twitter `href ="Inserisci l'URL qui"`</li><li>Digita il Nickname nel campo di testo</li></ul> |
 | :--------------------------------------------------------------------------------------------------------------------------- |
-| ![Change contact](readme-only/change-contact.PNG 'Inserisci il link del tuo account Twitter e digita il tuo Nickname')               |
+| ![Change contact](/readme-only/change-contact.PNG 'Inserisci il link del tuo account Twitter e digita il tuo Nickname')               |
 
-- Se preferisci utilizzare un metodo di contatto diverso da Twitter, dovrai sostituire l'icona di Twitter `<i class =" fa fa-twitter "> </i>` andando su [Font Awesome Icons] (http://fontawesome.io/icons/) cercando l'icona giusta e sostituendo solo la parte `fa-twitter` con la nuova icona come` fa-facebook` per esempio. Quindi seguire gli stessi passaggi descritti in precedenza.
+- Se preferisci utilizzare un metodo di contatto diverso da Twitter, dovrai sostituire l'icona di Twitter `<i class =" fa fa-twitter "> </i>` andando su [Font Awesome Icons](http://fontawesome.io/icons/) cercando l'icona giusta e sostituendo solo la parte `fa-twitter` con la nuova icona come` fa-facebook` per esempio. Quindi seguire gli stessi passaggi descritti in precedenza.
 
-| <ul><li>Raccontaci qualcosa di te</li><li>Scrivi qualcosa di breve e dolce. Dovrebbe essere qualcosa di simile a un tweet piuttosto che un post sul blog</li></ul> | ![Change about](readme-only/change-about.PNG 'Scrivi una frase su di te') |
+| <ul><li>Raccontaci qualcosa di te</li><li>Scrivi qualcosa di breve e dolce. Dovrebbe essere qualcosa di simile a un tweet piuttosto che un post sul blog</li></ul> | ![Change about](/readme-only/change-about.PNG 'Scrivi una frase su di te') |
 | :------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------: |
 
 
 | <ul> <li> Condividi con la community 3 collegamenti a risorse utili allo sviluppo web </li> <li> Può trattarsi di qualsiasi cosa, un video, un discorso, un podcast, un articolo, un riferimento o uno strumento </li> <li> Se sei un principiante, non lasciarti intimidire da questo, condividi ciò che sai anche se pensi che sia troppo basilare. Sarai sorpreso di quante persone ne trarranno beneficio </li></ul> |
 | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| ![Change resources](readme-only/change-resources.PNG 'Inserisci il link, scrivi una breve descrizione e digita il nome della risorsa')                                                                                                                                                                                                                                   |
+| ![Change resources](/readme-only/change-resources.PNG 'Inserisci il link, scrivi una breve descrizione e digita il nome della risorsa')                                                                                                                                                                                                                                   |
 | <ul> <li> Link: inserisci il link `href =" qui "` sostituendo il `#` </li> <li> Titolo: Scrivi una breve descrizione `title =" qui "` </li> <li> Nome: scrivi il nome della risorsa nel campo di testo `> qui </a>` </li> </ul>                                                                                                                                                               |
 
 
-- 	Assicurati di aver ** salvato tutte le modifiche **.
-- 	** Prova le tue modifiche **. QUESTO È IMPORTANTE! Apri il file html nel tuo browser (facendo doppio clic su di esso ad esempio) e guarda come apparirà la tua card sul sito. Assicurati che l'intera pagina sembri sempre la stessa e assicurati che non ci siano errori. Fai clic sui tuoi collegamenti(link) e assicurati che funzionino. Apri la console (Ctrl + Maiusc + J (Windows / Linux) o Cmd + Opt + J (Mac)) e verifica che non vi siano messaggi di errore.
+- 	Assicurati di aver **salvato tutte le modifiche**.
+- 	**Prova le tue modifiche**. QUESTO È IMPORTANTE! Apri il file html nel tuo browser (facendo doppio clic su di esso ad esempio) e guarda come apparirà la tua card sul sito. Assicurati che l'intera pagina sembri sempre la stessa e assicurati che non ci siano errori. Fai clic sui tuoi collegamenti(link) e assicurati che funzionino. Apri la console (Ctrl + Maiusc + J (Windows / Linux) o Cmd + Opt + J (Mac)) e verifica che non vi siano messaggi di errore.
 - 	Fantastico, hai finito di modificare il tuo codice! I passaggi successivi ti aiuteranno a inviare le modifiche a GitHub che le inoltrerà come richiesta per essere unite al progetto principale.
 
 ---
@@ -179,18 +179,18 @@ _ Tempo stimato: meno di 30 minuti_.
 
 - 	Torna all'app desktop GitHub.
 - 	Le modifiche saranno state aggiunte automaticamente all'area di gestione temporanea.
-- 	Ciò significa che Git ha registrato tutte le modifiche ** salvate **.
+- 	Ciò significa che Git ha registrato tutte le modifiche **salvate**.
 - 	Potrai vederlo nell'app. Tutto ciò che hai aggiunto al file sarà in verde e le eliminazioni verranno visualizzate in rosso.
 
-| <ul><li>Il prossimo passo è chiamato _Commit_</li><li>Ciò significa approssimativamente "confermare le modifiche"</li></ul> | ![Commit changes](readme-only/commit.PNG "Le modifiche che hai aggiunto dovrebbero apparire in verde sul lato destro dell'app desktop GitHub. Il pulsante di commit è in basso a sinistra") |
+| <ul><li>Il prossimo passo è chiamato _Commit_</li><li>Ciò significa approssimativamente "confermare le modifiche"</li></ul> | ![Commit changes](/readme-only/commit.PNG "Le modifiche che hai aggiunto dovrebbero apparire in verde sul lato destro dell'app desktop GitHub. Il pulsante di commit è in basso a sinistra") |
 | :-------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 
 
 | <ul><li>Ecco come dovrebbe apparire l'intestazione di GitHub desktop</li><li>Nota il simbolo della fork accanto al nome del progetto in "Current repository"</li><li>Il tuo `Current branch` avrà il nome che gli hai dato nel passaggio 3</li></ul> |
 | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ![Commit changes](readme-only/commit-header.PNG "Le modifiche che hai aggiunto dovrebbero apparire in verde sul lato destro dell'app GitHub desktop. Il pulsante di commit è in basso a sinistra")                                               |
+| ![Commit changes](/readme-only/commit-header.PNG "Le modifiche che hai aggiunto dovrebbero apparire in verde sul lato destro dell'app GitHub desktop. Il pulsante di commit è in basso a sinistra")                                               |
 
-| <ul><li>Per eseguire il _Commit_ devi compilare il campo _Summary_</li><li>Questo è il messaggio di commit che ti spiega cosa hai cambiato</li><li>In questo caso "Added my card information" sarebbe un messaggio corretto come spiegazione dei cambiamenti apportati</li><li>Opzionalmente è possibile aggiungere più dettagli alla _Descrizione_</li><li>fai Click sul pulsante _Commit_ . Il dovrà apparire più o meno così: `Commit in" your-branch-name "`</li></ul> | ![Write commit message and commit](readme-only/commit-message.PNG "Scrivi un breve messaggio di commit nell'input "summary" e fai clic su "commit"") |
+| <ul><li>Per eseguire il _Commit_ devi compilare il campo _Summary_</li><li>Questo è il messaggio di commit che ti spiega cosa hai cambiato</li><li>In questo caso "Added my card information" sarebbe un messaggio corretto come spiegazione dei cambiamenti apportati</li><li>Opzionalmente è possibile aggiungere più dettagli alla _Descrizione_</li><li>fai Click sul pulsante _Commit_ . Il dovrà apparire più o meno così: `Commit in" your-branch-name "`</li></ul> | ![Write commit message and commit](/readme-only/commit-message.PNG "Scrivi un breve messaggio di commit nell'input "summary" e fai clic su "commit"") |
 | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------: |
 
 
@@ -201,7 +201,7 @@ _ Tempo stimato: meno di 30 minuti_.
 - Le modifiche sono ora salvate o confermate(committed). Ma vengono salvate solo localmente, cioè sul tuo computer.
 - La sincronizzazione delle modifiche locali con il repository su Github si chiama _Push_. Stai "inviando" le modifiche dal tuo repository locale al repository remoto su Github.
 
-| <ul><li>fai click su _Push_ button</li></ul> | ![Push to GitHub](readme-only/push.PNG "Invia le tue modifiche a GitHub, fai clic sul pulsante "Push"") |
+| <ul><li>fai click su _Push_ button</li></ul> | ![Push to GitHub](/readme-only/push.PNG "Invia le tue modifiche a GitHub, fai clic sul pulsante "Push"") |
 | :---------------------------------------- | ------------------------------------------------------------------------------------------------: |
 
 
@@ -218,21 +218,21 @@ _ Tempo stimato: meno di 30 minuti_.
 - Vai alla pagina principale di ** your fork ** su GitHub (avrà l'icona della fork e il tuo nome utente in alto).
 - Verso la parte superiore del repository verrà visualizzato un messaggio di pull request evidenziato con un pulsante verde.
 
-| <ul><li>fai click su `Compare and pull request`</li></ul> | ![Submit a Pull Request](readme-only/pull-request.PNG 'Di solito è localizzato verso la parte superiore della pagina, sotto la descrizione e sopra i file e le cartelle del progetto') |
+| <ul><li>fai click su `Compare and pull request`</li></ul> | ![Submit a Pull Request](/readme-only/pull-request.PNG 'Di solito è localizzato verso la parte superiore della pagina, sotto la descrizione e sopra i file e le cartelle del progetto') |
 | :-------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
 
 
 | <ul><li>Ecco come appare la pagina `Open a pull request` .</li><li>RICORDA _che stai provando a fondere il tuo branch con il progetto originale, non con il branch "Master" sul tuo fork_.</li><li>L'immagine qui sotto ti dà un'idea di come dovrebbe apparire l'intestazione della tua richiesta pull.</li><li>A sinistra è situato il progetto originale, seguito dal branch principale. Sulla destra c'è il tuo fork e branch che hai creato.</li></ul> |
 | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ![Open a Pull Request](readme-only/pull-request-branches.PNG 'Stai chiedendo di unire il tuo branch dal tuo fork al branch principale del progetto originale')                                                                                                                                                                                                                                                                      |
+| ![Open a Pull Request](/readme-only/pull-request-branches.PNG 'Stai chiedendo di unire il tuo branch dal tuo fork al branch principale del progetto originale')                                                                                                                                                                                                                                                                      |
 
-| <ul><li>Crea una pull request:</li><li>Scrivi un titolo</li><li>Aggiungi informazioni opzionali nella descrizione</li><li>Fai Click su `Create pull request`</li></ul> | ![Submit a Pull Request](readme-only/pull-request-open.PNG "Fai clic sul pulsante verde. Non aver paura!") |
+| <ul><li>Crea una pull request:</li><li>Scrivi un titolo</li><li>Aggiungi informazioni opzionali nella descrizione</li><li>Fai Click su `Create pull request`</li></ul> | ![Submit a Pull Request](/readme-only/pull-request-open.PNG "Fai clic sul pulsante verde. Non aver paura!") |
 | :----------------------------------------------------------------------------------------------------------------------------------------------------- | -----------------------------------------------------------------------------------------------------: |
 
 
 - 	Non lasciarti stupire da tutte le opzioni. Per ora devi solo eseguire questi tre passaggi.
 - 	Lascia selezionata l'opzione "Consenti modifiche dai manutentori".
-- 	Ora, una _Pull Request_ verrà inviata al manutentore del progetto. Non appena esaminato e accettato, le modifiche verranno visualizzate nella [pagina web del progetto] (https://syknapse.github.io/Contribute-To-This-Project 'Contribuisci a questo progetto pagina Web').
+- 	Ora, una _Pull Request_ verrà inviata al manutentore del progetto. Non appena esaminato e accettato, le modifiche verranno visualizzate nella [pagina web del progetto](https://syknapse.github.io/Contribute-To-This-Project 'Contribuisci a questo progetto pagina Web').
 ---
 
 ### Step 10: Festeggiare!
@@ -241,7 +241,7 @@ Questo è tutto. ce l'hai fatta! Ora hai contribuito all'open source su GitHub.
 
 Hai aggiunto codice a una pagina web live: [https://syknapse.github.io/Contribute-To-This-Project lasting(https://syknapse.github.io/Contribute-To-This-Project)
 
-Le tue modifiche ** non saranno immediatamente visibili **; per prima cosa devono essere riviste, accettate e unite dal manutentore del progetto. Una volta unite, la tua card dovrebbe essere visibile e visibile sulla pagina.
+Le tue modifiche **non saranno immediatamente visibili**; per prima cosa devono essere riviste, accettate e unite dal manutentore del progetto. Una volta unite, la tua card dovrebbe essere visibile e visibile sulla pagina.
 
 È normale per un revisore chiedere modifiche su un PR. Pensalo come una buona pratica se ti succede. Tieni d'occhio commenti e modifiche richieste. Una volta apportate le modifiche richieste (di nuovo nel tuo branch) tutto ciò che devi fare è impegnarti e inviare le modifiche. Il PR si aggiornerà automaticamente con le nuove modifiche.
 
@@ -256,17 +256,17 @@ Prometto che proverò a rivedere e unire il prima possibile, ma lo faccio nel te
 
 - Torna tra un po' per verificare la tua richiesta pull unita.
 - Dovresti ricevere un'email da GitHub quando le modifiche sono state approvate o se sono richieste ulteriori modifiche. E quando il PR viene finalmente unito al master e la tua card è stata aggiunta.
-- Se hai trovato questo progetto ** utile ** ti preghiamo di dargli una: :star: star :star:  nella parte superiore della pagina e un ** Tweet ** per aiutare a spargere la voce [! [Tweet] (https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Contribute%20To%20This%20Project.%20An%20easy%20project%20for%20first-time%20contributors,%20with%20a%20full%20tutorial.%20By%20@Syknapse&url=https://github.com/Syknapse/Contribute-To-This-Project&hashtags=100Daysofode 'Tweet this project')
-- Puoi ** seguirmi ** e metterti in contatto su [Twitter] (https://twitter.com/Syknapse '@Syknapse') o [usando una di queste altre opzioni] (https://syknapse.github.io/Syk-Houdeib/#contact  'La mia sezione contatti | Portfolio')
-- Questo è un progetto open source, quindi oltre a contribuire con la tua card sei il benvenuto per aiutarci a correggere bug, miglioramenti o nuove funzionalità. Apri un [numero] (https://help.github.com/articles/creating-an-issue/ 'Problemi di mastering | Guide GitHub') o invia una nuova [richiesta pull] (https://help.github.com/articles/creating-a-pull-request-from-a-fork/  'Creazione di una richiesta pull da una fork | Guida di GitHub')
-- ** Grazie per aver contribuito a questo progetto **. Ora puoi andare avanti e provare a contribuire ad altri progetti; cerca l'etichetta! [Good First Issue] (https://user-images.githubusercontent.com/29199184/33852733-e23b7070-debb-11e7-907b-4e7a03aad436.png) per opzioni di contributo intuitive per i principianti.
+- Se hai trovato questo progetto **utile** ti preghiamo di dargli una: :star: star :star:  nella parte superiore della pagina e un ** Tweet **per aiutare a spargere la voce** [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Contribute%20To%20This%20Project.%20An%20easy%20project%20for%20first-time%20contributors,%20with%20a%20full%20tutorial.%20By%20@Syknapse&url=https://github.com/Syknapse/Contribute-To-This-Project&hashtags=100DaysofCode 'Twitta questo progetto')
+- Puoi **seguirmi** e metterti in contatto su [Twitter](https://twitter.com/Syknapse '@Syknapse') o [usando una di queste altre opzioni](https://syknapse.github.io/Syk-Houdeib/#contact  'La mia sezione contatti | Portfolio')
+- Questo è un progetto open source, quindi oltre a contribuire con la tua card sei il benvenuto per aiutarci a correggere bug, miglioramenti o nuove funzionalità. Apri un [numero](https://help.github.com/articles/creating-an-issue/ 'Problemi di mastering | Guide GitHub') o invia una nuova [richiesta pull](https://help.github.com/articles/creating-a-pull-request-from-a-fork/  'Creazione di una richiesta pull da una fork | Guida di GitHub')
+- **Grazie per aver contribuito a questo progetto** . Ora puoi andare avanti e provare a contribuire ad altri progetti; cerca l'etichetta ![Good First Issue](https://user-images.githubusercontent.com/29199184/33852733-e23b7070-debb-11e7-907b-4e7a03aad436.png) per opzioni di contributo intuitive per i principianti.
 - Cerco anche collaboratori che mi diano una mano nella revisione e nella fusione di PR. Se desideri avere una pratica Git più avanzata, inviami un DM su Twitter.
 
 ## Ringraziamenti
 
-Questo progetto è fortemente influenzato dal progetto [Roshan Jossey] (https://github.com/Roshanjossey) di grande [primo contributo] (https://github.com/Roshanjossey/first-contributions) con il suo eccellente tutorial.
+Questo progetto è fortemente influenzato dal progetto [Roshan Jossey](https://github.com/Roshanjossey) di grande [primo contributo] (https://github.com/Roshanjossey/first-contributions) con il suo eccellente tutorial.
 
-È particolarmente ispirato dalla grande comunità intorno a [#GoogleUdacityScholars] (https://twitter.com/hashtag/GoogleUdacityScholars?src=hash) La borsa di studio Google Challenge: Front-End Web Dev, classe 2017 Europa.
+È particolarmente ispirato dalla grande comunità intorno a [#GoogleUdacityScholars](https://twitter.com/hashtag/GoogleUdacityScholars?src=hash) La borsa di studio Google Challenge: Front-End Web Dev, classe 2017 Europa.
 
 ## Licenza di utilizzo
 


### PR DESCRIPTION
Hi, @Syknapse , I notice that some links and images are broken in the Italian translation and also in the Portuguese one.

So, I tried for fixing the images to add just a simple slash `/` before the image link and regarding the broken links, I simply remove the space between square and round brackets. As I'm concerned the reason for this issue may be that the translated files are stored in a different directory so the path for accessing the images is different.  I am new here on Github as you can see I've created my account only 9 days ago, so I don't know if it is the best practice but when I click "preview changes" it just works fine. Maybe this can solve the problem who knows... so please let me know... Also, I think that struggling with these problems is the best method to pragmatically understand how GitHub works and maybe I can learn something from it  ("you learn by your mistakes" or so they say...).


fixing images (added a single slash before "readme-only")

` ![Commit changes](/readme-only/image.PNG "description") `
instead of 
` ![Commit changes](readme-only/image.PNG "description") `

fixing links (remove the space between square and round brackets)

` ![Commit changes](readme-only/image.PNG "description") `
instead of
`![Commit changes] (readme-only/image.PNG "description") `