### PR TITLE
Fix issue between abulnes16 and Tanuj's card

### DIFF
--- a/index.html
+++ b/index.html
@@ -15807,7 +15807,7 @@
             <a href="http://twitter.com/GUSfiuza" target="_blank">@GUSfiuza</a>
           </p>
           <p class="about">
-            Matemático de formação, analista de TI por profissão e cientista de dados em formação.
+            Matemático de formação, analista de TI por profissão e cientista de dados em formação.
           </p>
           <div class="resources">
             <p>3 Useful Dev Resources</p>
@@ -20934,7 +20934,11 @@
               <li>
                 <a href="https://tobiasahlin.com/spinkit/" target="_blank" title="A handful animated loading spinners for you're projects">
                   Spinkit
-
+		</a>
+              </li>
+            </ul>
+          </div>
+        </div>
         <!-- ________ abulnes16 card END ________  -->
          
          <!-- ________ Tanuj's card START ________  -->


### PR DESCRIPTION
abulnes16’s card and Tanuj's card were overlapping, Tanuj’s card was placed above abulnes16’s card _(see screenshot below)_. 
This was because abulnes16’s card missed all of its closing tags, leading Tanuj’s card to be a child of abulnes16’s.
<img width="634" alt="issue" src="https://user-images.githubusercontent.com/44684757/105646046-e2a0d680-5e9d-11eb-80da-7cf45de77988.png">

