### PR TITLE
Fix Repo stat 

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ It is also particularly inspired by the great community around [#GoogleUdacitySc
 ![Close PR's](https://badgen.net/github/closed-prs/Syknapse/Contribute-To-This-Project)
 ![Merged PR's](https://badgen.net/github/merged-prs/Syknapse/Contribute-To-This-Project)
 
-![Repo Stat](https://github-readme-stats.vercel.app/api/pin/?username=Syknapse&repo=Contribute-To-This-Project&theme=dark&show_owner=true)
+![Repo Stat](https://github-readme-stats-git-masterrstaa-rickstaa.vercel.app/api/pin/?username=Syknapse&repo=Contribute-To-This-Project&theme=dark&show_owner=true)
 
 <h4 align="center">Maintainers</h4>
 


### PR DESCRIPTION
https://github.com/anuraghazra/github-readme-stats/issues/2415

Easy fix. Just change the github-readme-stats Default URL to another one.


(Before change the repository's README looks like this.)
![图片](https://user-images.githubusercontent.com/85282140/212708561-c26721a9-b30d-4496-90af-0f200f4e6cd1.png)
