### PR TITLE
Updated assets/style.css

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -251,6 +251,10 @@ footer {
   color: var(--orange);
 }
 
+.night .resources a:hover {
+  color: var(--orange);
+}
+
 .night .container {
   color: var(--light-grey1);
 }


### PR DESCRIPTION
I noticed that the hover effect of the resource list items in night mode was causing them to disappear because the color of the text was matching the background-color. I have added a new hover effect for night mode that changes the text to the same orange color that is used to display the font-awesome icon in night mode.

This is one of my first pull requests, so I hope that I have done everything correctly. If not, feel free to let me know.