### PR TITLE
Create ci for auto close pr, issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,8 +29,8 @@ jobs:
         with:
           # only for PR
           any-of-pr-labels: "changes requested"
-          stale-pr-message: "This PR is stale because it has been 1 days with no activity. Update PR or this will be closed in 6 days."
-          close-pr-message: "This PR was closed because it has been stalled for 7 days with no activity."
+          stale-pr-message: "This PR is stale because it has been 1 days with no activity. Update PR or this will be closed in 4 days."
+          close-pr-message: "This PR was closed because it has been stalled for 5 days with no activity."
           days-before-stale: 1
-          days-before-close: 6
+          days-before-close: 4 
           remove-pr-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+name: "Close stale issues and PR"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  intentions-not-clear:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          # for both PR and issues
+          any-of-labels: "intentions not clear"
+          stale-pr-message: "This PR is stale because it has been 1 days with no activity. Explain intention of this PR or this will be closed in 2 days."
+          close-pr-message: "This PR was closed because it has been stalled for 3 days with unclear intentions."
+          stale-issue-message: "This issue is stale because it has been 1 days with no activity. Explain intention of this PR or this will be closed in 2 days."
+          close-issue-message: "This issue was closed because it has been stalled for 3 days with unclear intentions."
+          days-before-stale: 1
+          days-before-close: 2
+          remove-stale-when-updated: true
+  changes-requested:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          # only for PR
+          any-of-pr-labels: "changes requested"
+          stale-pr-message: "This PR is stale because it has been 1 days with no activity. Update PR or this will be closed in 6 days."
+          close-pr-message: "This PR was closed because it has been stalled for 7 days with no activity."
+          days-before-stale: 1
+          days-before-close: 6
+          remove-pr-stale-when-updated: true


### PR DESCRIPTION
## intentions not clear:

- for both PR and issues
- stale after 1 day, leave comment about it will be closed
- if stale, close after 2 days, leave comment about why it's closed

## changes requested

- for PR only
- stale after 1 day, leave comment about it will be closed
- if stale, close after 6 days, leave comment about why it's closed

## Common
- if something changes during stale (comment/new commit/label ...), it won't be stale.
- Auto runs every day