### PR TITLE
mentioned user_handle in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,9 +120,9 @@
           <p class="name">Your name</p>
           <p class="contact">
             <i class="fab fa-x-twitter"></i>
-            <a href="https://www.twitter.com" target="_blank">Your handle</a>
+            <a href="https://www.twitter.com/your_user_handle" target="_blank">Your handle</a>
             <i class="fab fa-github"></i>
-            <a href="https://www.github.com" target="_blank">Your handle</a>
+            <a href="https://www.github.com/your_user_handle" target="_blank">Your handle</a>
           </p>
           <p class="about">about you</p>
           <div class="resources">


### PR DESCRIPTION
Since some new contributors are not mentioning their user handles in the link, when explicitly mention it in the URL, it tells them to add so. 