### PR TITLE
Resolve bad merge conflict from #3666

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,43 +519,6 @@
         </div>
         <!-- ________ Ramses Gutierrez card END ________  -->
 
-        <!-- ________ *TEMPLATE: MAKE A COPY* Contributor card START ________  -->
-        <div class="card">
-          <p class="name">Nick Francisco</p>
-          <p class="contact">
-            <i class="fab fa-github"></i>
-            <a href="https://github.com/NickFranciscoOSU" target="_blank">NickFranciscoOSU</a>
-          </p>
-          <p class="about">Computer Science Student at Oregon State University.</p>
-          <div class="resources">
-            <p>3 Useful Dev Resources</p>
-            <ul>
-              <li>
-                <a href="https://devdocs.io/react/" target="_blank" title="First Resource">React Documentation</a>
-              </li>
-              <li>
-                <a
-                  href="https://getbootstrap.com/docs/5.3/getting-started/introduction/"
-                  target="_blank"
-                  title="Second Resource"
-                >
-                  Bootstrap Documentation
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://developer.mozilla.org/en-US/docs/Web/JavaScript"
-                  target="_blank"
-                  title="Third resource"
-                >
-                  Javascript Documentation
-                </a>
-              </li>
-            </ul>
-          </div>
-        </div>
-        <!-- ________ *TEMPLATE: MAKE A COPY* Contributor card END ________  -->
-
         <!-- ________ KAPIPER card START ________  -->
         <div class="card">
           <p class="name">Kate Piper</p>


### PR DESCRIPTION
When resolving a merge conflict in #3666 it looked as if Git had removed the contributor's code, so I manually added it back in during conflict resolution.

It seemed weird though, so I took a look at what ended up getting merged in with the PR and discovered that the merge conflict editor on Github simply didn't show me the actually added card.

This PR fixes my mistake by removing the duplicate.