### PR TITLE
docs: add beginner-friendly issue templates (fixes #4223)

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/workflows/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,17 @@
+---
+name: 🪄 Good First Issue
+about: Simple issues for new contributors to start with
+title: "[Good First Issue] <add short title here>"
+labels: ["good first issue", "beginner friendly"]
+---
+
+### Description
+Describe the small feature, fix, or improvement clearly.
+
+### Steps
+1. Explain what needs to be done.
+2. Mention the file or folder where the change goes.
+3. Add any helpful links or screenshots.
+
+### Expected Outcome
+What should happen after fixing or improving this issue.

--- a/.github/workflows/ISSUE_TEMPLATE/typo_fix.md
+++ b/.github/workflows/ISSUE_TEMPLATE/typo_fix.md
@@ -1,0 +1,16 @@
+---
+name: ✏️ Fix Typos / Grammar
+about: Correct spelling or grammar mistakes in docs or comments
+title: "[Typo Fix] <file or section name>"
+labels: ["documentation", "good first issue"]
+---
+
+### Description
+Explain where you found the typo or grammar mistake.
+
+### Steps
+1. Point to the exact file and line if possible.
+2. Describe the correct wording.
+
+### Notes
+This helps improve clarity and readability for everyone.


### PR DESCRIPTION
### Summary
Added beginner-friendly issue templates to help new contributors.

### Changes
- Added `.github/ISSUE_TEMPLATE/good_first_issue.md`
- Added `.github/ISSUE_TEMPLATE/typo_fix.md`

### Why
Helps new contributors easily find simple tasks to start contributing.

### Related Issue
Fixes #4223
