### PR TITLE
feat: make dark mode persistent using localStorage (#4463)

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -59,6 +59,11 @@ numberOfFilesArray.forEach(number => {
       const grid = document.getElementById('contributions')
       // Add the cards to the grid
       grid.innerHTML += cards
+      // If we are in night mode, we need to apply it to the newly added cards
+      if (localStorage.getItem('theme') === 'night') {
+        const newlyAddedCards = grid.querySelectorAll('.card:not(.night)')
+        newlyAddedCards.forEach(card => card.classList.add('night'))
+      }
     })
     .catch(error => {
       console.error('Error importing archive JSON files:', error)
@@ -98,7 +103,16 @@ const countUp = () => {
 
 // night mode feature
 let nightModeIntervalId = null
-document.getElementById('toggle-box-checkbox').addEventListener('change', e => {
+const themeToggle = document.getElementById('toggle-box-checkbox')
+
+// Load theme from localStorage
+const currentTheme = localStorage.getItem('theme')
+if (currentTheme === 'night') {
+  document.body.classList.add('night')
+  themeToggle.checked = true
+}
+
+themeToggle.addEventListener('change', e => {
   // stop the last interval
   if (nightModeIntervalId) {
     clearInterval(nightModeIntervalId)
@@ -114,8 +128,10 @@ document.getElementById('toggle-box-checkbox').addEventListener('change', e => {
   // update background color first
   if (isNightMode) {
     document.body.classList.add('night')
+    localStorage.setItem('theme', 'night')
   } else {
     document.body.classList.remove('night') // change background color first
+    localStorage.setItem('theme', 'light')
   }
 
   const updateCount = 50 // how many cards to update in one cycle


### PR DESCRIPTION
## Description
This PR addresses the issue where the user's theme preference (Dark/Light mode) was lost upon page reload. I have implemented a persistence layer using `localStorage` to ensure the selected theme stays active across sessions.

### Changes:
- Added logic to save the theme preference to `localStorage` when the toggle is switched.
- Added a check on page load to retrieve and apply the stored theme from `localStorage`.
- Ensured the `theme` variable is used to maintain consistency.

## Related Issue
Fixes #4463

### Verification
1. Open the site and toggle Dark Mode.
2. Refresh the page ($F5$).
3. Observe that the Dark Mode remains active.
4. Close the tab and reopen; the preference should still be saved.