### PR TITLE
fix: Translation for Maintainer Guide

### DIFF
--- a/translations/maintainer_guide/maintainer_guide.ita.md
+++ b/translations/maintainer_guide/maintainer_guide.ita.md
@@ -5,7 +5,7 @@ Questa guida si rivolge a coloro che vogliono unirsi al progetto come manutentor
 ## Obiettivi
 
 Il nostro obiettivo principale è di fornire ai nostri contributori nel modo più rapido possibile dei riscontri e risposte dal momento in cui aprono la loro richiesta di unione codice (pull request). Questo si traduce principalmente in fornire revisioni di codice, ed unire "PRs" approvate.
-Inoltre, possiamo mantenere il progetto accertandoci che tutto funzioni correttamente nella maniera più utile per i nostri contributori.ontributors.
+Inoltre, possiamo mantenere il progetto accertandoci che tutto funzioni correttamente nella maniera più utile per i nostri contributori.
 
 ## A chi si rivolge?
 
@@ -27,29 +27,4 @@ Chiunque abbia un minimo di conoscenze Git e GitHub. Non è necessario essere es
 ### Richiedere modifiche
 
 - Alcune volte potrebbero esserci problemi con la PR che dovrebbero essere sistemati dal contributore, come la creazione di una "branch" (ramo) incorretta, HTML incorretto, informazioni mancanti, scheda inserita nel posto sbagliato. Tutto ciò che dimostri di non avere seguito correttamente il tutorial (e non semplici conflitti di unione).
-- Iniziare la revisione su GitHub e richiedere modifiche. Cercare di essere quanto più descrittivi possibile, commentare la linea esatta, informare loro esattamente di quale sia il problema e come sistemarlo, quindi incoraggiarli comunicando quanto questo sia normale nel processo di revisione di una PR.
-- Quando pronti, sottoporre la revisione.
-- Tenere d'occhio la conversazione nel caso il contributore abbia successive domande a cui si possa fornire aiuto. Il nostro obiettivo è che raggiunga il traguardo, proviamo quindi a guidarli fino alla fine.
-- Una volta che il contributore avrà fornito le modifiche richieste, la PR può essere unita a `master`.
-
-Per favore, verificare sempre che le modifiche non abbiano impattato le funzionalità del progetto e che la pagina "live" (in diretta) funzioni ancora come previsto. È sempre meglio verificare le modifiche in locale prima di unirle, e mai unire niente che risulti sospetto.
-
-## Strumenti
-
-Se non sono presenti troppe PR accumulate, questo intero processo può essere svolto direttamente nella pagina GitHub del progetto.
-Nonostante ciò, non è insolito avere alcune PR in attesa, e questo porterà inevitabilmente a dei conflitti. È consentito usare qualsiasi strumento con cui si abbia familiarità per vedere differenze e risolvere conflitti.
-Raccomandiamo l'uso di uno strumento come [GitKraken](https://www.gitkraken.com/download). È grafico e permette una gestione più facile del progetto quando ci sono diverse PR da revisionare.
-Scaricare GitKraken, quindi clonare il progetto. Usando una combinazione di editor di codice a voi familiare e lo strumento integrato di gestione conflitti di GitKraken fornirà il controllo totale per muoversi con rapidità tra le varie PR, risolvendo conflitti ed unendo il codice.
-
-Il progetto ha installato "Prettier" per assicurarsi che, a prescindere da come un contributore sottoponga la sua PR, la guida di stile verrà forzata. In questo modo il progetto è sempre mantenuto con la stessa indentazione e stile.
-Nel caso notiate che il file HTML risulti disordinato, eseguite `npx prettier --write index.html` nella cartella "root" (base) del progetto. Questo dovrebbe cercare di formattare il file e, nel caso fallisse, mostrerà quali errori ha incontrato. In certi casi un tag di chiusura mancante o HTML incorretto potrebbe essere unito per errore, e questo è un metodo valido per accorgersene e risolvere il problema.
-
-In caso di dubbi, è sempre possibile menzionare me o altri manutentori nella PR stessa, oppure inviarmi direttamente un messaggio diretto su [Twitter](https://twitter.com/Syknapse).
-
-## Unisciti
-
-Unisciti a noi per aiutare la crescita di questo progetto insieme. Contattami pure su Twitter e mandami il tuo account GitHub per essere aggiunto.
-
-_Questo documento non è stato tradotto dall'inglese direttamente da [Syknapse](https://github.com/Syknapse), in caso di contatto si suggerisce di usare l'inglese_
-
-[![Discord](https://badgen.net/discord/online-members/tWkvS4ueVF?label=Join%20Our%20Discord%20Server&icon=discord)](https://discord.gg/tWkvS4ueVF 'Join our Discord server!')
+- Iniziare la revisione su GitHub e richiedere modifiche. Cercare di


### PR DESCRIPTION
Summary

      - **translations/maintainer_guide/maintainer_guide.ita.md**: Minor formatting adjustments for better readability

      What changed
      Translate the Maintainer Guide into the desired language and update the existing translations according to the main English Doc.

       Testing
      I tested this locally and the changes work as expected. Happy to make any adjustments if needed!

      Closes #2881