### PR TITLE
fix: remove index.html from bot trigger + rename script.js to main.js

### DIFF
--- a/.github/workflows/validate-card-pr.yml
+++ b/.github/workflows/validate-card-pr.yml
@@ -10,7 +10,6 @@ on:
     branches: [master]
     paths:
       - 'cards/*.html'
-      - 'index.html'
 
 permissions:
   contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,11 @@ Each card is a standalone HTML fragment with this shape:
   <p class="name">...</p>
   <p class="contact"><!-- <i> icon + <a> link pairs --></p>
   <p class="about">...</p>
-  <div class="resources"><ul><!-- <li><a> items --></ul></div>
+  <div class="resources">
+    <ul>
+      <!-- <li><a> items -->
+    </ul>
+  </div>
 </div>
 ```
 
@@ -43,8 +47,8 @@ Each card is a standalone HTML fragment with this shape:
 
 - `archive/archiveFilesTotal.js` — auto-generated, exports `numberOfFiles` (integer)
 - `archive/json/archive_N.json` — arrays of card objects `{ name, contacts, about, resources }`
-- `assets/script.js` — imports `numberOfFiles`, fetches all `archive_N.json` files in parallel, renders each into `#contributions` via `innerHTML +=`; also handles night mode, search, contribution counter, and the scroll-to-top button
-- `index.html` — static shell; `#contributions` grid is empty on load, populated entirely by `script.js`
+- `assets/main.js` — imports `numberOfFiles`, fetches all `archive_N.json` files in parallel, renders each into `#contributions` via `innerHTML +=`; also handles night mode, search, contribution counter, and the scroll-to-top button
+- `index.html` — static shell; `#contributions` grid is empty on load, populated entirely by `main.js`
 
 ### Scripts directory
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,0 +1,237 @@
+import numberOfFiles from '../archive/archiveFilesTotal.js'
+
+const contributionsDisplay = document.getElementById('contributions-number')
+const displayClass = document.getElementById('contributions-number').classList
+let displayNumber = 0
+let searchTimeout = null
+
+// Create an array of ascending numbers corresponding with the number of archive files
+const numberOfFilesArray = Array.from({ length: numberOfFiles }, (_, index) => index + 1)
+const archiveCardsDirectory = './archive/json'
+
+// Import all archived cards and insert into the DOM
+numberOfFilesArray.forEach(number => {
+  // Fetch each JSON archive file based on its number
+  fetch(`${archiveCardsDirectory}/archive_${number}.json`)
+    .then(response => response.json())
+    .then(data => {
+      const file = `archive_${number}.json`
+      const link = `https://github.com/Syknapse/Contribute-To-This-Project/blob/master/archive/json/${file}`
+      // For each file iterate over the data and create an array of the HTML card template
+      const cards = data
+        .map(card => {
+          const { name, contacts, about, resources } = card
+          // Insert each user data into the template
+          return `
+            <div class="card">
+            <!-- Fetched from Archive: ${file} -->
+              <p class="name">${name}</p>
+              <p class="contact">
+              ${contacts
+                .map(
+                  contact => `
+                    <i class="${contact.icon}"></i>
+                    <a href="${contact.link}" target="_blank">${contact.handle}</a>
+                    `
+                )
+                .join('')}
+              </p>
+              <p class="about">${about}</p>
+              <div class="resources">
+                <p>3 Useful Dev Resources</p>
+                <ul>
+                ${resources
+                  .map(
+                    resource => `
+                    <li>
+                      <a href="${resource.link}" target="_blank" title="${resource.title}">${resource.text}</a>
+                    </li>
+                  `
+                  )
+                  .join('')}
+                </ul>
+              </div>
+              <p><small>Fetched From: <a href="${link}" target="_blank">${file}</a></small></p>
+            </div>
+          `
+        })
+        .join('')
+      const grid = document.getElementById('contributions')
+      // Add the cards to the grid
+      grid.innerHTML += cards
+      // If we are in night mode, we need to apply it to the newly added cards
+      if (localStorage.getItem('theme') === 'night') {
+        const newlyAddedCards = grid.querySelectorAll('.card:not(.night)')
+        newlyAddedCards.forEach(card => card.classList.add('night'))
+      }
+    })
+    .catch(error => {
+      console.error('Error importing archive JSON files:', error)
+    })
+    .finally(() => countUp())
+})
+
+// Prompt to archive when there are too many cards
+const showInfoInConsole = () => {
+  const cardsInIndex = document.getElementsByClassName('card').length - 1
+
+  console.info('Cards in index.html:', cardsInIndex)
+  if (cardsInIndex > 100)
+    console.warn(
+      `Too many cards in index.html: ${cardsInIndex}. Run the archive_cards script. Follow instructions in archive/archiving_cards_guide`
+    )
+}
+showInfoInConsole()
+
+// display for the number of contributions
+const countUp = () => {
+  const numberOfCards = document.getElementsByClassName('card').length
+  const numberOfContributors = numberOfCards - 1 // minus the example card
+
+  setTimeout(() => {
+    if (displayNumber < numberOfContributors) {
+      displayNumber++
+      contributionsDisplay.textContent = displayNumber
+      countUp()
+    }
+
+    if (displayNumber === numberOfContributors) {
+      displayClass.add('rubberBand')
+    }
+  }, 15)
+}
+
+// night mode feature
+let nightModeIntervalId = null
+const themeToggle = document.getElementById('toggle-box-checkbox')
+
+// Load theme from localStorage
+const currentTheme = localStorage.getItem('theme')
+if (currentTheme === 'night') {
+  document.body.classList.add('night')
+  themeToggle.checked = true
+}
+
+themeToggle.addEventListener('change', e => {
+  // stop the last interval
+  if (nightModeIntervalId) {
+    clearInterval(nightModeIntervalId)
+  }
+
+  // NOTE: clicking button before card is fetched will cause the card not updated
+  const cards = document.getElementsByClassName('card')
+  const { length: cardCount } = cards
+  let cardIndex = 0 // which card we're updating
+
+  const { checked: isNightMode } = e.target
+
+  // update background color first
+  if (isNightMode) {
+    document.body.classList.add('night')
+    localStorage.setItem('theme', 'night')
+  } else {
+    document.body.classList.remove('night') // change background color first
+    localStorage.setItem('theme', 'light')
+  }
+
+  const updateCount = 50 // how many cards to update in one cycle
+  const updateInterval = 500
+
+  const updateCardCss = () => {
+    for (let i = 0; i < updateCount; i++) {
+      if (cardIndex + i >= cardCount) {
+        clearInterval(nightModeIntervalId)
+        return
+      }
+
+      if (isNightMode) {
+        cards[cardIndex + i].classList.add('night')
+      } else {
+        cards[cardIndex + i].classList.remove('night')
+      }
+    }
+    cardIndex += updateCount
+  }
+
+  // update all cards in several cycles, update every cards' css at once will cause lag
+  updateCardCss() // update the first 50 cards
+  nightModeIntervalId = setInterval(updateCardCss, updateInterval)
+})
+
+// Current year for footer
+const currentYearSpan = document.getElementById('currentYear')
+const currentYear = new Date().getFullYear()
+currentYearSpan.innerText = currentYear
+
+// Search bar
+const searchBar = document.getElementById('searchbar')
+searchBar.addEventListener('input', searchCard)
+
+function clearSearchHighlights() {
+  const marks = Array.from(document.querySelectorAll('mark'))
+  if (marks.length > 0) {
+    marks.forEach(mark => {
+      mark.outerHTML = mark.innerText
+    })
+  }
+}
+
+function applyHighlightToSearchResults(value, card) {
+  const regex = new RegExp(value, 'gi')
+  const cardElements = Array.from(card.querySelectorAll('*'))
+  const matches = cardElements.filter(
+    element => element.children.length === 0 && element.textContent.toLowerCase().includes(value)
+  )
+
+  if (value && value.length > 0) {
+    matches.forEach(match => (match.innerHTML = match.textContent.replaceAll(regex, `<mark>$&</mark>`)))
+  }
+}
+
+function searchCard() {
+  const input = searchBar.value.toLowerCase()
+
+  if (searchTimeout) {
+    clearTimeout(searchTimeout)
+  }
+
+  searchTimeout = setTimeout(async () => {
+    const cards = document.getElementsByClassName('card')
+
+    clearSearchHighlights()
+
+    for (let i = 0; i < cards.length; i++) {
+      if (!cards[i].textContent.toLowerCase().includes(input)) {
+        cards[i].style.display = 'none'
+      } else {
+        cards[i].style.display = 'flex'
+        applyHighlightToSearchResults(input, cards[i])
+      }
+    }
+  }, 500) // 500 millisecond delay between keystrokes to trigger the search
+}
+
+// Get the button
+let topButton = document.getElementById('topButton')
+
+// When the user scrolls down 500px from the top of the document, show the button
+let scrollDebounceId = null
+window.addEventListener('scroll', () => {
+  if (scrollDebounceId) clearTimeout(scrollDebounceId)
+  scrollDebounceId = setTimeout(scrollFunction, 100)
+})
+function scrollFunction() {
+  if (document.body.scrollTop > 500 || document.documentElement.scrollTop > 500) {
+    topButton.style.display = 'flex'
+  } else {
+    topButton.style.display = 'none'
+  }
+}
+
+// When the user clicks on the button, scroll to the top of the document
+function topFunction() {
+  document.body.scrollTop = 0 // For Safari
+  document.documentElement.scrollTop = 0 // For Chrome, Firefox, IE and Opera
+}
+
+topButton.addEventListener('click', topFunction)

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <title>Contribute To This Project</title>
-    <script type="module" src="assets/script.js" defer=""></script>
+    <script type="module" src="assets/main.js" defer=""></script>
   </head>
   <body>
     <div class="container">

--- a/scripts/validate-card-pr.js
+++ b/scripts/validate-card-pr.js
@@ -49,20 +49,6 @@ const README = `https://github.com/${GITHUB_REPOSITORY}#readme`
 const prFiles = JSON.parse(gh(`gh pr view ${PR_NUMBER} --json files`)).files.map(f => f.path)
 console.log(`Changed files: ${prFiles.join(', ')}`)
 
-// ── index.html redirect ────────────────────────────────────────────────────────
-if (prFiles.includes('index.html')) {
-  postComment(`Hi @${PR_AUTHOR}! 👋
-
-Thanks for contributing! We recently updated how cards are added to this project.
-
-**The new way:** Instead of editing \`index.html\`, copy \`cards/template.html\` to \`cards/your-github-username.html\`, fill it in, and open a PR with just that file. The bot validates and auto-merges — no waiting!
-
-See the [README](${README}) for the updated step-by-step tutorial. This PR is being closed — please don't be discouraged, re-submitting with the new flow takes just a few minutes. 🙌`)
-  gh(`gh pr close ${PR_NUMBER}`)
-  console.log(`PR #${PR_NUMBER} closed with redirect comment.`)
-  process.exit(0)
-}
-
 // ── file scope ─────────────────────────────────────────────────────────────────
 const nonCardFiles = prFiles.filter(f => !/^cards\/[^/]+\.html$/.test(f))
 if (nonCardFiles.length > 0) {


### PR DESCRIPTION
## Problem
The `validate-card-pr` workflow had `index.html` in its trigger paths. Any maintainer PR that touched `index.html` (like the `script.js` rename) caused the bot to fire the v1 redirect comment and close the PR.

## Root cause fix

**`validate-card-pr.yml`** — removed `index.html` from trigger paths. The bot only needs to fire on `cards/*.html`. That's the only file a card contributor ever submits.

**`validate-card-pr.js`** — removed the `index.html` redirect block entirely. The v1 migration is complete. `index.html` no longer has a card template section, so the redirect scenario can't happen — a contributor following an old tutorial would have nothing to add there.

## Also included
Lands the `assets/script.js` → `assets/main.js` rename (closes #4509) that was incorrectly killed by this bug.

## What to review
- `validate-card-pr.yml`: only `cards/*.html` in paths now
- `validate-card-pr.js`: redirect block gone, file scope check unchanged
- `assets/main.js`: renamed from `script.js`, no other changes
- `index.html`: src updated to `assets/main.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)