### PR TITLE
fix: remove index.html from bot trigger path + drop v1 redirect

### DIFF
--- a/.github/workflows/validate-card-pr.yml
+++ b/.github/workflows/validate-card-pr.yml
@@ -10,7 +10,6 @@ on:
     branches: [master]
     paths:
       - 'cards/*.html'
-      - 'index.html'
 
 permissions:
   contents: write

--- a/scripts/validate-card-pr.js
+++ b/scripts/validate-card-pr.js
@@ -49,20 +49,6 @@ const README = `https://github.com/${GITHUB_REPOSITORY}#readme`
 const prFiles = JSON.parse(gh(`gh pr view ${PR_NUMBER} --json files`)).files.map(f => f.path)
 console.log(`Changed files: ${prFiles.join(', ')}`)
 
-// ── index.html redirect ────────────────────────────────────────────────────────
-if (prFiles.includes('index.html')) {
-  postComment(`Hi @${PR_AUTHOR}! 👋
-
-Thanks for contributing! We recently updated how cards are added to this project.
-
-**The new way:** Instead of editing \`index.html\`, copy \`cards/template.html\` to \`cards/your-github-username.html\`, fill it in, and open a PR with just that file. The bot validates and auto-merges — no waiting!
-
-See the [README](${README}) for the updated step-by-step tutorial. This PR is being closed — please don't be discouraged, re-submitting with the new flow takes just a few minutes. 🙌`)
-  gh(`gh pr close ${PR_NUMBER}`)
-  console.log(`PR #${PR_NUMBER} closed with redirect comment.`)
-  process.exit(0)
-}
-
 // ── file scope ─────────────────────────────────────────────────────────────────
 const nonCardFiles = prFiles.filter(f => !/^cards\/[^/]+\.html$/.test(f))
 if (nonCardFiles.length > 0) {


### PR DESCRIPTION
## Problem
The `validate-card-pr` workflow had `index.html` in its trigger paths. Any maintainer PR touching `index.html` caused the bot to fire the v1 redirect and close the PR.

## Fix
- **`validate-card-pr.yml`**: remove `index.html` from trigger paths — the bot only needs to fire on `cards/*.html`
- **`validate-card-pr.js`**: remove the `index.html` redirect block entirely — the v1 migration is complete; `index.html` no longer has a card template section so this scenario can't happen

## This PR intentionally does NOT touch index.html
To avoid triggering the very bug it fixes. The `script.js → main.js` rename (closes #4509) will follow in a separate PR once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)