### PR TITLE
refactor: rename assets/script.js to assets/main.js

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,11 @@ Each card is a standalone HTML fragment with this shape:
   <p class="name">...</p>
   <p class="contact"><!-- <i> icon + <a> link pairs --></p>
   <p class="about">...</p>
-  <div class="resources"><ul><!-- <li><a> items --></ul></div>
+  <div class="resources">
+    <ul>
+      <!-- <li><a> items -->
+    </ul>
+  </div>
 </div>
 ```
 
@@ -43,8 +47,8 @@ Each card is a standalone HTML fragment with this shape:
 
 - `archive/archiveFilesTotal.js` — auto-generated, exports `numberOfFiles` (integer)
 - `archive/json/archive_N.json` — arrays of card objects `{ name, contacts, about, resources }`
-- `assets/script.js` — imports `numberOfFiles`, fetches all `archive_N.json` files in parallel, renders each into `#contributions` via `innerHTML +=`; also handles night mode, search, contribution counter, and the scroll-to-top button
-- `index.html` — static shell; `#contributions` grid is empty on load, populated entirely by `script.js`
+- `assets/main.js` — imports `numberOfFiles`, fetches all `archive_N.json` files in parallel, renders each into `#contributions` via `innerHTML +=`; also handles night mode, search, contribution counter, and the scroll-to-top button
+- `index.html` — static shell; `#contributions` grid is empty on load, populated entirely by `main.js`
 
 ### Scripts directory
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -3,7 +3,7 @@ import numberOfFiles from '../archive/archiveFilesTotal.js'
 const contributionsDisplay = document.getElementById('contributions-number')
 const displayClass = document.getElementById('contributions-number').classList
 let displayNumber = 0
-let searchTimeout = null;
+let searchTimeout = null
 
 // Create an array of ascending numbers corresponding with the number of archive files
 const numberOfFilesArray = Array.from({ length: numberOfFiles }, (_, index) => index + 1)
@@ -189,26 +189,26 @@ function applyHighlightToSearchResults(value, card) {
 }
 
 function searchCard() {
-  const input = searchBar.value.toLowerCase();
+  const input = searchBar.value.toLowerCase()
 
   if (searchTimeout) {
-    clearTimeout(searchTimeout);
+    clearTimeout(searchTimeout)
   }
 
   searchTimeout = setTimeout(async () => {
-    const cards = document.getElementsByClassName('card');
+    const cards = document.getElementsByClassName('card')
 
-    clearSearchHighlights();
+    clearSearchHighlights()
 
     for (let i = 0; i < cards.length; i++) {
       if (!cards[i].textContent.toLowerCase().includes(input)) {
-        cards[i].style.display = 'none';
+        cards[i].style.display = 'none'
       } else {
-        cards[i].style.display = 'flex';
-        applyHighlightToSearchResults(input, cards[i]);
+        cards[i].style.display = 'flex'
+        applyHighlightToSearchResults(input, cards[i])
       }
     }
-  }, 500); // 500 millisecond delay between keystrokes to trigger the search
+  }, 500) // 500 millisecond delay between keystrokes to trigger the search
 }
 
 // Get the button

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <title>Contribute To This Project</title>
-    <script type="module" src="assets/script.js" defer=""></script>
+    <script type="module" src="assets/main.js" defer=""></script>
   </head>
   <body>
     <div class="container">


### PR DESCRIPTION
## Summary
Renames `assets/script.js` → `assets/main.js` to clearly distinguish the frontend entry point from the `scripts/` Node.js automation directory.

Updates `index.html` (src reference) and `CLAUDE.md`. History docs left unchanged.

Closes #4509

> Note: an earlier attempt at this PR was incorrectly closed by the bot (fixed in #4518). This PR touches `index.html` — the bot no longer triggers on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)