### PR TITLE
fix: align dark mode card hover with light mode

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -266,10 +266,12 @@ footer {
 
 .night.card {
   border: 1px solid var(--orange);
+  color: var(--light-grey1);
 }
 
 .night.card:hover {
-  background-color: var(--orange);
+  /* Keep hover behavior consistent with light theme: animation only, no recoloring. */
+  background-color: transparent;
 }
 
 .toggle-box-label-left:empty {


### PR DESCRIPTION
Removes dark mode-specific card recoloring on hover. Keeps hover interaction consistent with light mode (animation only). Ensures readable default text color in dark mode card content.