### PR TITLE
fix: archive via pull_request_target instead of premature workflow_dispatch

### DIFF
--- a/.github/workflows/card-to-archive.yml
+++ b/.github/workflows/card-to-archive.yml
@@ -1,10 +1,11 @@
 name: Archive Card
 
-# Primary trigger: workflow_dispatch dispatched by validate-card-pr.yml after merge.
-# workflow_dispatch is NOT suppressed by GITHUB_TOKEN (unlike push/PR events),
-# so it fires reliably even when the merge was performed by a workflow token.
+# Primary trigger: pull_request_target:[closed] fires after the PR is actually
+# merged — guaranteed to run after the card file lands on master.
+# pull_request_target is not suppressed by GITHUB_TOKEN, so it fires reliably
+# even when auto-merge (triggered by a workflow token) does the merge.
 #
-# Fallback: pull_request_target:[closed] for any merges not dispatched above.
+# workflow_dispatch is kept for manual re-runs (e.g. if the primary trigger fails).
 on:
   workflow_dispatch:
     inputs:

--- a/scripts/validate-card-pr.js
+++ b/scripts/validate-card-pr.js
@@ -113,20 +113,11 @@ ${errorList}
 Don't hesitate to ask if anything is unclear — we're happy to help! 🙌`)
 }
 
-// ── success: merge then dispatch archive ───────────────────────────────────────
+// ── success: enable auto-merge ─────────────────────────────────────────────────
 // Branch protection is required on master, so --auto is always available.
-// The PR will merge automatically once all required status checks pass.
+// The PR merges automatically once all required status checks pass.
+// card-to-archive.yml is triggered by pull_request_target:[closed] after the
+// actual merge — no dispatch needed here.
 console.log(`✅ Card is valid — merging PR #${PR_NUMBER}`)
 gh(`gh pr merge ${PR_NUMBER} --squash --auto`)
 console.log('🎉 Auto-merge enabled — will merge once all checks pass.')
-
-// Dispatch card-to-archive.yml via workflow_dispatch.
-// workflow_dispatch is NOT suppressed by GITHUB_TOKEN (unlike push/PR events),
-// so this fires reliably regardless of how the merge was performed.
-try {
-  gh(`gh workflow run card-to-archive.yml --ref master -f filename=${filename}`)
-  console.log(`📦 Dispatched card-to-archive for ${filename}`)
-} catch (err) {
-  console.log(`⚠️  Could not dispatch card-to-archive: ${err.message.split('\n')[0]}`)
-  console.log('   The pull_request_target:[closed] trigger will handle it as fallback.')
-}


### PR DESCRIPTION
## Problem
`validate-card-pr.js` was dispatching `card-to-archive.yml` immediately after enabling auto-merge. But `--auto` is asynchronous — the card file isn't on master yet when the archive workflow runs, causing a "file not found" error.

## Fix
Remove the dispatch from `validate-card-pr.js` entirely. `card-to-archive.yml` already has a `pull_request_target:[closed]` trigger which fires after the actual merge — the card is guaranteed to be on master at that point. `workflow_dispatch` is kept for manual re-runs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)