### PR TITLE
Add contributor card for xingzihai

### DIFF
--- a/cards/xingzihai.html
+++ b/cards/xingzihai.html
@@ -1,0 +1,26 @@
+<!-- =========================================================== -->
+<!--  Contributor card for xingzihai                              -->
+<!-- =========================================================== -->
+
+<div class="card">
+  <p class="name">xingzihai</p>
+  <p class="contact">
+    <i class="fab fa-github"></i>
+    <a href="https://github.com/xingzihai" target="_blank">xingzihai</a>
+  </p>
+  <p class="about">开源爱好者，正在学习AI和Web开发</p>
+  <div class="resources">
+    <p>3 Useful Dev Resources</p>
+    <ul>
+      <li>
+        <a href="https://github.com/" target="_blank" title="GitHub - Where the world builds software">GitHub</a>
+      </li>
+      <li>
+        <a href="https://developer.mozilla.org/" target="_blank" title="MDN Web Docs - Resources for developers">MDN Web Docs</a>
+      </li>
+      <li>
+        <a href="https://www.freecodecamp.org/" target="_blank" title="freeCodeCamp - Learn to code for free">freeCodeCamp</a>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
This PR adds a contributor card for xingzihai as per the project guidelines.

## Changes
- Added `cards/xingzihai.html` with contributor information

## Contributor Info
- **Name:** xingzihai
- **GitHub:** https://github.com/xingzihai
- **About:** 开源爱好者，正在学习AI和Web开发

## Resources Shared
1. GitHub - Where the world builds software
2. MDN Web Docs - Resources for developers
3. freeCodeCamp - Learn to code for free

This is my contribution following the tutorial in README.md.