### PR TITLE
fix: enforce Prettier formatting across all PRs

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,91 @@
+name: Auto Format
+
+# Runs on every PR (including forks) with pull_request_target so it has write
+# access to push formatting fixes back to the PR branch.
+#
+# Security: we never run npm install from the fork. Prettier is invoked via npx
+# (no fork code executed). The prettier config and .prettierignore are fetched
+# directly from master (trusted), overwriting any fork-modified versions.
+#
+# If the fork has "Allow edits from maintainers" enabled (GitHub default for new
+# PRs), the bot pushes the fix directly. If not, it posts a comment instead.
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Cancel any in-progress format run for the same PR when a new commit arrives.
+concurrency:
+  group: auto-format-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use head SHA (not ref) to avoid TOCTOU races
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Override with trusted Prettier config from master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch config files from the base repo (master) to prevent a malicious
+          # fork from injecting a custom prettier.config.js or .prettierignore.
+          gh api "repos/${{ github.repository }}/contents/prettier.config.js?ref=master" \
+            --jq '.content' | base64 -d > prettier.config.js
+          gh api "repos/${{ github.repository }}/contents/.prettierignore?ref=master" \
+            --jq '.content' | base64 -d > .prettierignore
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
+      - name: Format with Prettier
+        # Run via npx — never executes the fork's npm install or postinstall scripts.
+        # Pinned to major version 3, matching our package.json (^3.8.1).
+        run: npx --yes prettier@3 --write --ignore-unknown --ignore-path .prettierignore .
+
+      - name: Commit and push formatting fixes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "All files already formatted — nothing to do."
+            exit 0
+          fi
+
+          git commit -am "style: auto-format with Prettier [skip ci]"
+
+          if git push; then
+            echo "Formatting fixes pushed to PR branch."
+          else
+            echo "Push failed — fork may not allow edits from maintainers. Posting comment."
+            printf '%s\n' \
+              "Hi! 👋 Some files in this PR need formatting with [Prettier](https://prettier.io)." \
+              "" \
+              "To fix this, run the following in the project root and push the result:" \
+              "" \
+              '```bash' \
+              "npm install" \
+              "npm run format" \
+              '```' \
+              "" \
+              "Alternatively, install the [Prettier VS Code extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and enable **Format on Save** — it will handle this automatically." \
+              > /tmp/format-comment.md
+            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/format-comment.md
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          # Check out the PR branch so we format the contributor's actual changes
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
       - name: Set up Node.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 .DS_Store
 .vscode/*
 !.vscode/settings.json
+!.vscode/extensions.json
 .vs
-.vscode
 node_modules
 .idea
 archive_test

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "prettier.requireConfig": true
+}


### PR DESCRIPTION
## Problem

Two distinct failures were blocking non-card PRs:

**1. Merge-base error** (`Unable to locate commit sha`): The `prettier` job in `ci.yml` checked out the fork's repository with a custom `ref`/`repository`. When `tj-actions/changed-files` tried to diff against master's HEAD, it couldn't find that commit in the fork's shallow clone — particularly after direct-push commits (like the deploy-key archive bot) that forks never fetch.

**2. Unformatted contributor files**: Contributors submitting via GitHub web editor, GitHub Desktop, or any workflow without `npm install` have no Prettier running locally. The CI check would fail with no automated path to fix it.

## Solution

### Fix 1 — `ci.yml` (merge-base error)
Remove the custom `ref` and `repository` overrides from the `prettier` job checkout. For `pull_request` events, GitHub's default checkout creates a merge commit with the correct history that `tj-actions/changed-files` can diff against correctly. The `html-validation` job always used the default checkout and never had this problem.

### Fix 2 — `auto-format.yml` (new workflow)
A `pull_request_target` workflow that auto-formats every PR and pushes fixes directly to the PR branch — so contributors never need to know about Prettier.

**Security:** never runs the fork's `npm install`. Prettier runs via `npx` (pinned to major version 3). The `prettier.config.js` and `.prettierignore` are fetched from master (trusted), overwriting any fork versions.

**Fallback:** if the fork disables "Allow edits from maintainers", the bot posts a comment with the exact commands to run instead.

### Fix 3 — `.vscode/` settings
Format-on-save with Prettier as the default formatter for VS Code users. Also fixes `.gitignore` which had a standalone `.vscode` entry that was re-ignoring the directory and overriding the existing `!.vscode/settings.json` exception.

## Test plan
- [ ] CI passes on this PR
- [ ] Open a test PR with an unformatted file — confirm auto-format bot commits a fix
- [ ] Open a test PR with a valid card — confirm auto-format finds nothing to do (cards excluded via `.prettierignore`)
- [ ] Confirm the merge-base error no longer appears on fork PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)