### PR TITLE
fix: re-trigger CI after auto-format push via workflow_dispatch

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 # Cancel any in-progress format run for the same PR when a new commit arrives.
 concurrency:
@@ -88,6 +89,13 @@ jobs:
           # a specific SHA (detached HEAD), so git push needs a destination.
           if git push origin HEAD:${{ github.event.pull_request.head.ref }}; then
             echo "Formatting fixes pushed to PR branch."
+            # GitHub suppresses CI runs triggered by GITHUB_TOKEN pushes (anti-loop
+            # protection). Explicitly re-trigger CI so the prettier check passes
+            # on the now-formatted commit and auto-merge can proceed.
+            gh workflow run ci.yml \
+              --ref ${{ github.event.pull_request.head.ref }} \
+              -f ref=${{ github.event.pull_request.head.ref }}
+            echo "CI re-triggered on ${{ github.event.pull_request.head.ref }}."
           else
             echo "Push failed — fork may not allow edits from maintainers. Posting comment."
             printf '%s\n' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,15 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  # Allows auto-format.yml to re-trigger CI after pushing a formatting fix.
+  # GitHub suppresses workflow runs from GITHUB_TOKEN pushes, so the bot
+  # explicitly dispatches this workflow instead.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch ref to check'
+        required: true
+        type: string
 jobs:
   prettier:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `ci.yml` so auto-format can explicitly re-trigger CI after pushing a formatting fix
- Auto-format now calls `gh workflow run ci.yml` after a successful push (GitHub suppresses CI runs from GITHUB_TOKEN pushes as an anti-loop protection)
- Adds `actions: write` permission to `auto-format.yml` so it can dispatch workflows

## Why this is needed

GitHub's GITHUB_TOKEN push suppression means that after the auto-format bot pushes a formatting fix, CI does not automatically re-run on the new commit. Without this fix, the PR sits with a stale CI result and branch protection never clears.

## Test plan

- [ ] Open a test PR with an unformatted file
- [ ] Verify auto-format runs, commits fix, pushes to PR branch
- [ ] Verify CI re-runs on the new commit (triggered via `workflow_dispatch`)
- [ ] Verify CI passes and PR can be merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)