### PR TITLE
feat: add PR template and auto-labeling workflow (#4498)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!-- markdownlint-disable MD041 -->
+<!-- Delete the section that doesn't apply to your PR -->
+
+---
+
+## 🃏 Submitting a card?
+
+- [ ] I copied `cards/template.html` to `cards/my-github-username.html` — I did NOT edit `template.html` itself
+- [ ] My filename matches my exact GitHub username
+- [ ] I replaced all placeholder text with my own information
+- [ ] My PR only contains my one card file
+- [ ] I did not change any other code in the project
+
+---
+
+## 📝 Making another type of change?
+
+### What does this PR change?
+
+<!-- 1–2 lines is enough -->
+
+### Why?
+
+<!-- Link the issue this resolves, or briefly explain if there's no issue -->
+
+Resolves #
+
+### Type of change
+
+- [ ] Translation
+- [ ] Bug fix
+- [ ] Improvement / enhancement
+- [ ] New feature
+- [ ] Other
+
+### Checklist
+
+- [ ] I've linked the relevant issue above (or explained why there isn't one)
+- [ ] My changes only touch the files relevant to this PR
+- [ ] I've tested locally where applicable

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,36 @@
+name: Label PR
+
+# Runs on pull_request_target so GITHUB_TOKEN has write access to label
+# fork PRs. Only reads file paths — no PR code is checked out or executed.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+    branches: [master]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels based on changed files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FILES=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json files --jq '.files[].path')
+
+          apply_label() {
+            gh pr edit ${{ github.event.pull_request.number }} \
+              --repo ${{ github.repository }} \
+              --add-label "$1"
+          }
+
+          echo "$FILES" | grep -q '^cards/.*\.html$'  && apply_label "card-submission" || true
+          echo "$FILES" | grep -q '^translations/'    && apply_label "translation"      || true
+          echo "$FILES" | grep -qE '^(docs/|[^/]+\.md$)' && apply_label "documentation" || true
+          echo "$FILES" | grep -qE '^(assets/|scripts/)' && apply_label "enhancement"   || true
+          echo "$FILES" | grep -q '^\.github/'        && apply_label "ci"               || true


### PR DESCRIPTION
## Summary

- Two-section PR template — card checklist for contributors, structured form for other changes; contributor deletes whichever doesn't apply
- Auto-labeling workflow applies labels on PR open/synchronize based on changed file paths (`card-submission`, `translation`, `documentation`, `enhancement`, `ci`)
- Created `card-submission` label

Closes #4498

🤖 Generated with [Claude Code](https://claude.com/claude-code)