### PR TITLE
feat: fix visibility of fetched <small> text on dark mode cards

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -301,6 +301,16 @@ body.night {
   background-color: var(--dark-purple);
 }
 
+
+.night .card p small {
+  color: var(--light-grey1);
+  transition: color 0.25s ease-in-out;
+}
+
+.night .card:hover p small {
+  color: var(--dark-purple); 
+}
+
 .night.card .resources:hover {
   color: var(--pink);
   background-color: var(--purple);


### PR DESCRIPTION
Fixes #4514

This PR resolves the visibility issue for fetched `<small>` text in night mode cards.  
- Default: light-grey text on dark background  
- Hover: dark text on bright-orange background for readability  