### PR TITLE
chore: update cheerio to stable 1.2.0 (#4496)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "cheerio": "^1.0.0-rc.12"
+    "cheerio": "^1.2.0"
   },
   "lint-staged": {
     "*.{js,yml,yaml,json}": "prettier --write",


### PR DESCRIPTION
Updates `cheerio` from `^1.0.0-rc.12` (pre-release RC) to `^1.2.0` (stable).

Closes #4496

🤖 Generated with [Claude Code](https://claude.com/claude-code)