### PR TITLE
feat: remove jQuery/animate.css, fix fonts, add native rubberBand animation

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -16,7 +16,7 @@ body {
   background-position: 100% 0%;
   transition: all 1s;
   box-sizing: border-box;
-  font-family: 'Poppins', arial, sans-serif;
+  font-family: 'Roboto', arial, sans-serif;
 }
 
 html {
@@ -437,8 +437,36 @@ body.night {
 }
 
 @keyframes animate {
-  50%{
+  50% {
     transform: translateY(8px);
+  }
+}
+
+.rubberBand {
+  animation: rubberBand 1s ease;
+}
+
+@keyframes rubberBand {
+  0% {
+    transform: scale3d(1, 1, 1);
+  }
+  30% {
+    transform: scale3d(1.25, 0.75, 1);
+  }
+  40% {
+    transform: scale3d(0.75, 1.25, 1);
+  }
+  50% {
+    transform: scale3d(1.15, 0.85, 1);
+  }
+  65% {
+    transform: scale3d(0.95, 1.05, 1);
+  }
+  75% {
+    transform: scale3d(1.05, 0.95, 1);
+  }
+  100% {
+    transform: scale3d(1, 1, 1);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -3,14 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <link rel="stylesheet" href="assets/style.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,700" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" />
     <link href="https://fonts.googleapis.com/css2?family=Domine&amp;display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.4.2/css/all.css" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.5.2/animate.min.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <title>Contribute To This Project</title>
     <script type="module" src="assets/main.js" defer=""></script>
@@ -26,11 +24,6 @@
               <label for="toggle-box-checkbox" class="toggle-box-label-left"></label>
               <label for="toggle-box-checkbox" class="toggle-box-label"></label>
             </div>
-            <script
-              src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.3/jquery.min.js"
-              integrity="sha512-STof4xm1wgkfm7heWqFJVn58Hm3EtS31XFaagaa8VMReCXAkQnJZ+jEy8PCC/iT18dFy95WcExNHFTqLyp72eQ=="
-              crossorigin="anonymous"
-            ></script>
           </div>
           <!-- / Night Mode Creation -->
         </div>


### PR DESCRIPTION
## Summary

Bundles issues #4487, #4488, #4489, #4490, #4491 — frontend cleanup pass.

- **#4487** Remove jQuery 3.6.3 — loaded but completely unused (86KB saved per page load)
- **#4488** Remove `X-UA-Compatible` meta tag — IE compatibility directive, IE is dead
- **#4489** Update Google Fonts to `css2` syntax with `display=swap`
- **#4490** Remove animate.css CDN link; replace with native `@keyframes rubberBand` in `style.css`
- **#4491** Fix `font-family`: replace non-imported `Poppins` with already-loaded `Roboto`

## Test plan

- [ ] No jQuery or animate.css in browser Network tab
- [ ] Contribution counter still bounces on page load (native CSS rubberBand)
- [ ] Fonts render correctly (Roboto)
- [ ] Night mode still works
- [ ] HTML validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)