### PR TITLE
feat: add Web Share API button, CSP meta tag, remove Twitter widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 > Logo Created with :sparkling_heart: By [CandidDeer](https://github.com/CandidDeer)
 
-[![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)][twit]
-
 [![Discord](https://badgen.net/discord/online-members/tWkvS4ueVF?label=Join%20Our%20Discord%20Server&icon=discord)](https://discord.gg/tWkvS4ueVF 'Join our Discord server!')
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://syknapse.github.io/Contribute-To-This-Project/)
 [![Open Source Love](https://badges.frapsoft.com/os/v2/open-source.svg?v=103)](https://syknapse.github.io/Contribute-To-This-Project/)
@@ -332,7 +330,7 @@ Your card will be automatically reviewed and merged if everything is correct. If
 - Come back in a while to check for your merged Pull Request.
 - You should receive an email from GitHub when your card has been merged. And you can always check back on your PR page to see its status.
 - You can also learn how to contribute from this _free_ series: [How to Contribute to an Open Source Project on GitHub](https://kcd.im/pull-request)
-- If you found this project **useful** please give it a :star: star :star: at the top of the page and **Tweet** about it to help spread the word [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)][twit]
+- If you found this project **useful** please give it a :star: star :star: at the top of the page and share it to help spread the word
 - You can join our [Discord server](https://discord.gg/tWkvS4ueVF)
 - You can **follow me** and get in touch on [𝕏 (Twitter)](https://twitter.com/Syknapse '@Syknapse') or [using any of these other options](https://syknapse.github.io/Syk-Houdeib/#contact 'My contact section | Portfolio')
 - This is an open source project so apart from contributing your card you are welcome to help fix bugs, make improvements, or add new features. Read the [Contributing Guide](CONTRIBUTING.md) to see what's welcome and how to get started
@@ -359,5 +357,3 @@ This project is licensed under the [MIT License](./LICENSE).
 [![GitHub Contributors Image](https://contrib.rocks/image?repo=Syknapse/Contribute-To-This-Project)](https://github.com/Syknapse/Contribute-To-This-Project/graphs/contributors)
 
 [Back to the top &uparrow;](#introduction)
-
-[twit]: https://twitter.com/intent/tweet?text=Contribute%20To%20This%20Project.%20An%20easy%20project%20for%20first-time%20contributors,%20with%20a%20full%20tutorial.%20By%20@Syknapse&url=https://github.com/Syknapse/Contribute-To-This-Project&hashtags=100DaysofCode 'Tweet this project'

--- a/assets/main.js
+++ b/assets/main.js
@@ -284,6 +284,34 @@ function searchCard() {
   }, 500)
 }
 
+// ── share button ───────────────────────────────────────────────────────────────
+// Uses the Web Share API on supported browsers (mobile + modern desktop).
+// Falls back to copying the URL to clipboard on unsupported browsers (Firefox).
+
+const shareButton = document.getElementById('shareButton')
+
+shareButton.addEventListener('click', async () => {
+  const shareData = {
+    title: 'Contribute To This Project',
+    text: 'Contribute To This Project. An easy Git and GitHub project for first-time contributors, with a full tutorial.',
+    url: 'https://syknapse.github.io/Contribute-To-This-Project/',
+  }
+
+  if (navigator.share) {
+    try {
+      await navigator.share(shareData)
+    } catch {
+      // User cancelled the share dialog — do nothing
+    }
+  } else {
+    // Fallback: copy URL to clipboard
+    await navigator.clipboard.writeText(shareData.url)
+    const original = shareButton.innerHTML
+    shareButton.innerHTML = '<i class="fas fa-check"></i> Copied!'
+    setTimeout(() => (shareButton.innerHTML = original), 2000)
+  }
+})
+
 // ── scroll to top ──────────────────────────────────────────────────────────────
 // Shows a "back to top" button once the user has scrolled 500px down.
 // Scroll events are debounced to avoid running on every pixel of scroll.

--- a/assets/style.css
+++ b/assets/style.css
@@ -86,9 +86,25 @@ p {
   outline: none;
 }
 
-.twitter-button {
+.share-button-container {
   text-align: right;
   margin-bottom: 24px;
+}
+
+#shareButton {
+  padding: 10px 18px;
+  color: var(--white);
+  border-radius: 5px;
+  background: linear-gradient(90deg, var(--pink) 0%, var(--orange) 100%);
+  border: none;
+  font-size: 15px;
+  cursor: pointer;
+  box-shadow: var(--box-shadow);
+  transition: all 0.4s ease-in-out;
+}
+
+#shareButton:hover {
+  box-shadow: 4px 5px 27px 4px rgba(195, 164, 48, 1);
 }
 
 #contributions-number {

--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     <title>Contribute To This Project</title>
     <script type="module" src="assets/main.js" defer=""></script>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com; img-src * data:; object-src 'none'; base-uri 'self';"
+    />
   </head>
   <body>
     <div class="container">
@@ -50,21 +54,11 @@
         </div>
         <div class="column">
           <div class="column-right">
-            <div class="twitter-button">
-              <a
-                href="https://twitter.com/share?ref_src=twsrc%5Etfw"
-                class="twitter-share-button"
-                data-size="large"
-                data-text="Contribute To This Project. An easy Git and GitHub project for first-time contributors, with a full tutorial."
-                data-url="https://github.com/Syknapse/Contribute-To-This-Project"
-                data-via="Syknapse"
-                data-hashtags="100DaysOfCode"
-                data-show-count="false"
-                title="Tweet this project"
-              >
-                Tweet
-              </a>
-              <script async="" src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            <div class="share-button-container">
+              <button id="shareButton" type="button" aria-label="Share this project">
+                <i class="fas fa-share-nodes"></i>
+                Share
+              </button>
             </div>
             <p>Contributions so far...</p>
             <div class="animated" id="contributions-number">0</div>


### PR DESCRIPTION
## Summary

Closes #4499.

- **CSP meta tag** added to `index.html` — locks script execution to `'self'` only. Even if a malicious `javascript:` URI or inline event handler slipped past card validation, the browser refuses to execute it. CDNs (Google Fonts, FontAwesome) explicitly allowlisted. `img-src *` allows contributor profile images from any host.
- **Twitter widget removed** — `platform.twitter.com/widgets.js` injects inline scripts at runtime, which would have required `unsafe-inline` in `script-src`, completely defeating the CSP. The widget was replaced instead.
- **Web Share API button** — native browser share dialog (mobile: OS share sheet; desktop Chrome/Edge/Safari: share dialog). Fallback for unsupported browsers (Firefox): copies URL to clipboard, button briefly shows "Copied!". No third-party scripts, no tracking.
- **README** — removed Tweet badge and `[twit]` reference link.

## Impact on contribution flow

None. CSP is enforced by the browser on page load only. The validation bot, archive pipeline, CI/CD, and GitHub PR flow are completely unaffected.

## Test plan

- [ ] Browser devtools → Network tab: no `platform.twitter.com` or any third-party script requests
- [ ] Browser devtools → Console: no CSP violation errors
- [ ] Share button visible on page; clicking opens native share dialog (or copies URL on Firefox)
- [ ] Night mode, search, counter animation, archive loading all still work
- [ ] HTML validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)