### PR TITLE
fix: escape special regex characters in search input

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -256,7 +256,8 @@ function clearSearchHighlights() {
 
 function highlightMatchesInCard(searchValue, cardElement) {
   // Only highlight leaf nodes (elements with no children) that contain the search term
-  const regex = new RegExp(searchValue, 'gi')
+  const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const regex = new RegExp(escaped, 'gi')
   const leafNodes = Array.from(cardElement.querySelectorAll('*')).filter(
     element => element.children.length === 0 && element.textContent.toLowerCase().includes(searchValue)
   )


### PR DESCRIPTION
## Summary

Closes #4494.

User input like `.`, `*`, `+`, `(`, `)` was passed directly into `new RegExp()` in the search handler. Any of these characters throws a `SyntaxError` and search silently breaks for that keystroke.

**Fix:** escape all special regex metacharacters before constructing the `RegExp`.

```js
const escaped = searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
const regex = new RegExp(escaped, 'gi')
```

## Test plan

- [ ] Type `.` in the search bar — no console error, matches literal dots
- [ ] Type `(` or `*` — no error, search still filters cards correctly
- [ ] Normal text search still highlights and filters as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)