### PR TITLE
fix: specify --repo in auto-format to prevent fork context mismatch

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -65,6 +65,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CHANGED=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
             --json files --jq '[.files[].path] | join(" ")')
           if [ -z "$CHANGED" ]; then
             echo "No changed files found."
@@ -107,5 +108,5 @@ jobs:
               "" \
               "Alternatively, install the [Prettier VS Code extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and enable **Format on Save** — it will handle this automatically." \
               > /tmp/format-comment.md
-            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/format-comment.md
+            gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file /tmp/format-comment.md
           fi


### PR DESCRIPTION
## Summary

Fixes a bug where the auto-format workflow silently failed on all fork PRs.

## Root cause

The workflow checks out the fork's repository (`contributor/Contribute-To-This-Project`), which sets the local git remote to the fork URL. When `gh pr view <number>` runs without `--repo`, `gh` infers the repo from that remote — and looks for the PR in the **fork**, not the base repo. Since the PR doesn't exist in the fork, it errors:

```
GraphQL: Could not resolve to a PullRequest with the number of 4553. (repository.pullRequest)
```

This means auto-format has never worked for any fork PR since it was introduced. It only worked for PRs from branches within the main repo (our own test PRs).

## Fix

Add `--repo ${{ github.repository }}` to both `gh` calls that reference the PR number, pinning them to the base repo regardless of what is checked out:

- `gh pr view` (used to get the list of changed files)
- `gh pr comment` (used to post the fallback formatting instructions)

## Verified against

PR #4553 (Safa Maqbool) — the first real fork PR that exposed this bug. The auto-format job failed there with the exact error above.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>