### PR TITLE
perf: replace innerhtml += with insertAjacentHTML in renderCards()

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -69,7 +69,7 @@ function renderCards(cardDataArray, sourceFile) {
     .join('')
 
   const grid = document.getElementById('contributions')
-  grid.innerHTML += cardsHtml
+  grid.insertAdjacentHTML('beforeend', cardsHtml)
 }
 
 // ── lazy loading ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Related issue
Closes #4607

### What changes does this PR do?
Replaced grid.innerHTML += cardsHtml with 
grid.insertAdjacentHTML('beforeend', cardsHtml) 
in the renderCards() function in assets/main.js

This avoids re-serializing and rebuilding the entire 
DOM on every append, making it an O(n) operation 
instead of O(n²).


### Questions
None