### PR TITLE
fix: restore missing cards/template.html

### DIFF
--- a/cards/template.html
+++ b/cards/template.html
@@ -1,0 +1,33 @@
+<!-- =========================================================== -->
+<!--  HOW TO ADD YOUR CARD                                       -->
+<!--  1. Copy this file to cards/your-github-username.html       -->
+<!--  2. Fill in every field below (remove placeholder text)     -->
+<!--  3. Open a pull request ΓÇö the bot validates and auto-merges -->
+<!--  See README.md for the full step-by-step tutorial           -->
+<!-- =========================================================== -->
+
+<div class="card">
+  <p class="name">Your name</p>
+  <p class="contact">
+    <!-- Add one or more contact links. At minimum, include your GitHub. -->
+    <!-- Icon classes come from Font Awesome 5 (fab = brand icons)       -->
+   
+    <a href="https://www.github.com/your_user_handle" target="_blank"> <i class="fab fa-github"></i>Your handle</a>
+  </p>
+  <p class="about">Write a sentence or two about yourself.</p>
+  <div class="resources">
+    <p>3 Useful Dev Resources</p>
+    <ul>
+      <!-- Replace # with a real URL. -->
+      <li>
+        <a href="#" target="_blank" title="First Resource">Resource 1</a>
+      </li>
+      <li>
+        <a href="#" target="_blank" title="Second Resource">Resource 2</a>
+      </li>
+      <li>
+        <a href="#" target="_blank" title="Third Resource">Resource 3</a>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## 📝 Making another type of change?

### What does this PR change?

Restores `cards/template.html` that was accidentally renamed in PR #4681 instead of copied.

### Why?

Resolves #4691 

New contributors following the README instructions find no template file to copy from.

### Type of change

- [ ] Translation
- [ ] Bug fix
- [ ] Improvement / enhancement
- [ ] New feature
- [X] Other

### Checklist

- [X] I've linked the relevant issue above (or explained why there isn't one)
- [X] My changes only touch the files relevant to this PR
- [X] I've tested locally where applicable
