### PR TITLE
Restore cards template file

### DIFF
--- a/cards/template.html
+++ b/cards/template.html
@@ -1,0 +1,33 @@
+<!-- =========================================================== -->
+<!--  HOW TO ADD YOUR CARD                                       -->
+<!--  1. Copy this file to cards/your-github-username.html       -->
+<!--  2. Fill in every field below (remove placeholder text)     -->
+<!--  3. Open a pull request — the bot validates and auto-merges -->
+<!--  See README.md for the full step-by-step tutorial           -->
+<!-- =========================================================== -->
+
+<div class="card">
+  <p class="name">Your name</p>
+  <p class="contact">
+    <!-- Add one or more contact links. At minimum, include your GitHub. -->
+    <!-- Icon classes come from Font Awesome 5 (fab = brand icons)       -->
+    <i class="fab fa-github"></i>
+    <a href="https://www.github.com/your_user_handle" target="_blank">Your handle</a>
+  </p>
+  <p class="about">Write a sentence or two about yourself.</p>
+  <div class="resources">
+    <p>3 Useful Dev Resources</p>
+    <ul>
+      <!-- Replace # with a real URL. -->
+      <li>
+        <a href="#" target="_blank" title="First Resource">Resource 1</a>
+      </li>
+      <li>
+        <a href="#" target="_blank" title="Second Resource">Resource 2</a>
+      </li>
+      <li>
+        <a href="#" target="_blank" title="Third Resource">Resource 3</a>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
## What changed

Restores `cards/template.html` so new contributors can follow the README and CONTRIBUTING instructions again.

## Why

The README's Step 4 tells contributors to copy `cards/template.html`, but the file is currently missing from the `cards/` directory. This restores the template content from the repo's existing history.

Fixes #4691.

## Validation

- `prettier --check cards/template.html`
- `html-validate cards/template.html`