### PR TITLE
Restore missing cards template

### DIFF
--- a/cards/template.html
+++ b/cards/template.html
@@ -1,0 +1,33 @@
+<!-- =========================================================== -->
+<!--  HOW TO ADD YOUR CARD                                       -->
+<!--  1. Copy this file to cards/your-github-username.html       -->
+<!--  2. Fill in every field below (remove placeholder text)     -->
+<!--  3. Open a pull request — the bot validates and auto-merges -->
+<!--  See README.md for the full step-by-step tutorial           -->
+<!-- =========================================================== -->
+
+<div class="card">
+  <p class="name">Your name</p>
+  <p class="contact">
+    <!-- Add one or more contact links. At minimum, include your GitHub. -->
+    <!-- Icon classes come from Font Awesome 5 (fab = brand icons)       -->
+    <i class="fab fa-github"></i>
+    <a href="https://www.github.com/your_user_handle" target="_blank">Your handle</a>
+  </p>
+  <p class="about">Write a sentence or two about yourself.</p>
+  <div class="resources">
+    <p>3 Useful Dev Resources</p>
+    <ul>
+      <!-- Replace # with a real URL. -->
+      <li>
+        <a href="#" target="_blank" title="First Resource">Resource 1</a>
+      </li>
+      <li>
+        <a href="#" target="_blank" title="Second Resource">Resource 2</a>
+      </li>
+      <li>
+        <a href="#" target="_blank" title="Third Resource">Resource 3</a>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
## Making another type of change?

- [x] I am fixing a bug / broken file, not submitting a card.
- [x] This PR restores the missing `cards/template.html` file from git history.
- [x] No other files have been changed.

## What changed?

Restored `cards/template.html`, which was accidentally renamed instead of copied in PR #4681.

This restores the starter template required by the README for new contributors.

Resolves #4691