### PR TITLE
fix: security harden workflows against command injection

### DIFF
--- a/.github/workflows/card-to-archive.yml
+++ b/.github/workflows/card-to-archive.yml
@@ -54,10 +54,11 @@ jobs:
         id: card
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_FILENAME: ${{ inputs.filename }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # Filename passed directly as input
-            FILENAME="${{ inputs.filename }}"
+            FILENAME="$INPUT_FILENAME"
           else
             # Detect from PR's changed files (fallback pull_request_target path)
             FILENAME=$(gh pr view ${{ github.event.pull_request.number }} --json files \
@@ -73,19 +74,23 @@ jobs:
 
       - name: Archive card
         if: steps.card.outputs.filename != ''
+        env:
+          CARD_FILENAME: ${{ steps.card.outputs.filename }}
         run: |
-          FILE="cards/${{ steps.card.outputs.filename }}"
+          FILE="cards/$CARD_FILENAME"
           echo "Formatting and archiving $FILE..."
           npx prettier --write "$FILE"
-          node scripts/card-to-archive.js "${{ steps.card.outputs.filename }}"
+          node scripts/card-to-archive.js "$CARD_FILENAME"
 
       - name: Commit archived card
         if: steps.card.outputs.filename != ''
+        env:
+          CARD_FILENAME: ${{ steps.card.outputs.filename }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add archive/json/ archive/manifest.json
           git add -A cards/
           git diff --cached --quiet && echo "Nothing to commit" && exit 0
-          git commit -m "archive card: ${{ steps.card.outputs.filename }} [skip ci]"
+          git commit -m "archive card: $CARD_FILENAME [skip ci]"
           git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,13 @@ jobs:
 
       - name: Check formatting with Prettier
         if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           # cards/*.html and archive files are excluded via .prettierignore
           # --ignore-unknown skips files Prettier has no parser for (extensionless files, etc.)
-          npx prettier --check --ignore-unknown --ignore-path .prettierignore ${{ steps.changed-files.outputs.all_changed_files }}
+          # shellcheck disable=SC2086
+          npx prettier --check --ignore-unknown --ignore-path .prettierignore $ALL_CHANGED_FILES
 
   html-validation:
     runs-on: ubuntu-latest
@@ -55,10 +58,13 @@ jobs:
 
       - name: Validate HTML files
         if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           echo "Validating HTML files..."
-          echo "Changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
-          npx html-validate ${{ steps.changed-files.outputs.all_changed_files }}
+          echo "Changed files: $ALL_CHANGED_FILES"
+          # shellcheck disable=SC2086
+          npx html-validate $ALL_CHANGED_FILES
         continue-on-error: false
 
       - name: Validate index.html (always run on master)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

---

### What does this PR change?
Hardens GitHub Action workflows (`ci.yml` and `card-to-archive.yml`) against shell command injection by replacing direct template interpolation with environment variables.

### Why?
Resolves #4721

### Type of change
- [x] Bug fix
- [ ] Improvement / enhancement
- [ ] New feature
- [ ] Other

### Checklist
- [x] I've linked the relevant issue above (or explained why there isn't one)
- [x] My changes only touch the files relevant to this PR
- [ ] I've tested locally where applicable