### PR TITLE
fix: allow checking out fork branches in auto-format

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -40,6 +40,7 @@ jobs:
           # Use head SHA (not ref) to avoid TOCTOU races
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          allow-unsafe-pr-checkout: true
 
       - name: Override with trusted Prettier config from master
         env:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

---

### What does this PR change?
Adds `allow-unsafe-pr-checkout: true` to the `actions/checkout` step in `auto-format.yml`.

### Why?
Resolves #4722 by enabling the workflow to pull and auto-format fork branches under the `pull_request_target` runner context.

### Type of change
- [x] Bug fix

### Checklist
- [x] I've linked the relevant issue above (or explained why there isn't one)
- [x] My changes only touch the files relevant to this PR
