### PR TITLE
fix: restore cards/template.html

### DIFF
--- a/cards/template.html
+++ b/cards/template.html
@@ -1,0 +1,33 @@
+<!-- =========================================================== -->
+<!--  HOW TO ADD YOUR CARD                                       -->
+<!--  1. Copy this file to cards/your-github-username.html       -->
+<!--  2. Fill in every field below (remove placeholder text)     -->
+<!--  3. Open a pull request — the bot validates and auto-merges -->
+<!--  See README.md for the full step-by-step tutorial           -->
+<!-- =========================================================== -->
+
+<div class="card">
+  <p class="name">Your name</p>
+  <p class="contact">
+    <!-- Add one or more contact links. At minimum, include your GitHub. -->
+    <!-- Icon classes come from Font Awesome 5 (fab = brand icons)       -->
+   
+    <a href="https://www.github.com/your_user_handle" target="_blank"> <i class="fab fa-github"></i>Your handle</a>
+  </p>
+  <p class="about">Write a sentence or two about yourself.</p>
+  <div class="resources">
+    <p>3 Useful Dev Resources</p>
+    <ul>
+      <!-- Replace # with a real URL. -->
+      <li>
+        <a href="#" target="_blank" title="First Resource">Resource 1</a>
+      </li>
+      <li>
+        <a href="#" target="_blank" title="Second Resource">Resource 2</a>
+      </li>
+      <li>
+        <a href="#" target="_blank" title="Third Resource">Resource 3</a>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
Closes #4691

**Problem:** \cards/template.html\ was renamed to \cards/Lu-86.html\ in #4681 instead of being copied. New contributors following README Step 4 hit a missing file.

**Fix:** Restored \	emplate.html\ from history (\dfb7da9\) so tutorial works again. Verified file validates and matches original template.

No other files changed.